### PR TITLE
chore(devex): add npm scripts and extend Prettier to scss/js/yml

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,18 @@
       "options": {
         "parser": "go-template"
       }
+    },
+    {
+      "files": ["*.scss"],
+      "options": { "parser": "scss" }
+    },
+    {
+      "files": ["*.js"],
+      "options": { "parser": "babel" }
+    },
+    {
+      "files": ["*.yml", "*.yaml"],
+      "options": { "parser": "yaml" }
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 This theme is a Hugo project focused on layouts and assets. Keep changes small, reversible, and consistent with existing patterns.
 
 ## Project Structure & Module Organization
+
 - `layouts/`: Hugo templates (Go templates). Includes `_default/`, `partials/`, and page-type layouts.
 - `assets/`: Source assets compiled by Hugo Pipes (CSS/SCSS, JS, images, icons).
 - `example_site/`: Local preview content. Use it to test changes interactively.
@@ -10,6 +11,7 @@ This theme is a Hugo project focused on layouts and assets. Keep changes small, 
 - `theme.toml`: Theme metadata; bump min Hugo version or tags when required.
 
 ## Build, Test, and Development Commands
+
 - Preview locally: `hugo serve -s example_site --themesDir .. -t pochi`
   - Serves the example site with live reload.
 - Format check: `npx prettier . --check`
@@ -17,6 +19,7 @@ This theme is a Hugo project focused on layouts and assets. Keep changes small, 
   - Uses `prettier-plugin-go-template` to format Go template HTML.
 
 ## Coding Style & Naming Conventions
+
 - Indentation: 2 spaces; avoid tabs.
 - Templates: Prefer small, composable partials under `layouts/partials/`.
 - Naming: kebab-case for files (`post-card.html`), lowercase for asset files.
@@ -24,17 +27,19 @@ This theme is a Hugo project focused on layouts and assets. Keep changes small, 
 - JS: Keep DOM hooks prefixed (`data-pochi-*`) to prevent conflicts.
 
 ## Testing Guidelines
+
 - Manual testing via `hugo serve` on `example_site/` pages: home, posts, pagination, 404, robots.
 - Cross-browser smoke check for critical pages; verify no console errors.
 - No unit test suite at present; add reproducible steps in PRs for bug fixes.
 
 ## Commit & Pull Request Guidelines
+
 - Commits: Imperative mood, concise scope (e.g., `fix(list): correct ellipsis wrap`).
 - PRs: Clear description, before/after screenshots for UI, link issues (`#123`), and steps to verify.
 - Keep diffs focused; include migration notes if breaking template variables or CSS classes.
 
 ## Security & Configuration Tips
+
 - Do not commit secrets; `.env` files are out of scope for a theme.
 - Validate third-party assets’ licenses; prefer local, optimized assets in `assets/`.
 - Maintain compatibility with the `theme.toml` declared Hugo version.
-

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -59,7 +59,7 @@ function toggleSideNav() {
       sideNav.classList.add(isActiveClass);
       document.body.insertAdjacentHTML(
         "beforeend",
-        '<div id="side-nav-overlay"></div>'
+        '<div id="side-nav-overlay"></div>',
       );
       sideNavOverlay = document.querySelector("#side-nav-overlay");
     }
@@ -107,7 +107,7 @@ function buildTableOfContents() {
     }
 
     const headers = document.querySelectorAll(
-      "article h2, article h3, article h4, article h5, article h6"
+      "article h2, article h3, article h4, article h5, article h6",
     );
     let tableOfContents =
       '<div class="table-of-contents"><p><span>Table of Contents</span></p><ol>';
@@ -209,7 +209,7 @@ function executeSearch(searchQuery) {
   fetch("/index.json").then(function (response) {
     if (response.status !== 200) {
       console.log(
-        "Looks like there was a problem. Status Code: " + response.status
+        "Looks like there was a problem. Status Code: " + response.status,
       );
       return;
     }
@@ -247,7 +247,7 @@ function makeFeaturedImageContainer(featuredImageURL) {
   let container = "";
   if (featuredImageURL !== "") {
     const fileExtension = featuredImageURL.match(
-      /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/i
+      /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/i,
     )[0];
     const isAVIF = fileExtension === ".avif";
     const isWebP = fileExtension === ".webp";
@@ -260,11 +260,11 @@ function makeFeaturedImageContainer(featuredImageURL) {
 
       const jpgPath = featuredImageURL.replace(
         /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/i,
-        ".jpg"
+        ".jpg",
       );
       const pngPath = featuredImageURL.replace(
         /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/i,
-        ".png"
+        ".png",
       );
 
       if (urlExists(jpgPath)) {
@@ -289,7 +289,7 @@ function populateResults(results) {
 
   // pull template from hugo template definition
   var templateDefinition = document.getElementById(
-    "search-result-template"
+    "search-result-template",
   ).innerHTML;
 
   results.forEach(function (value, key) {
@@ -352,7 +352,7 @@ function hide(elem) {
 }
 function param(name) {
   return decodeURIComponent(
-    (location.search.split(name + "=")[1] || "").split("&")[0]
+    (location.search.split(name + "=")[1] || "").split("&")[0],
   ).replace(/\+/g, " ");
 }
 

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -1,5 +1,9 @@
 // Base layer (kept minimal since reboot.scss handles resets)
-@import 'variables';
+@import "variables";
 
-html { -webkit-overflow-scrolling: touch; }
-body { font-family: $font-family-base; }
+html {
+  -webkit-overflow-scrolling: touch;
+}
+body {
+  font-family: $font-family-base;
+}

--- a/assets/scss/_layout.scss
+++ b/assets/scss/_layout.scss
@@ -1,3 +1,3 @@
 // Layout layer. Import layout-specific partials here.
-@import 'layout/main-content';
-@import 'layout/grid';
+@import "layout/main-content";
+@import "layout/grid";

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -19,13 +19,20 @@
 
 @mixin respond($breakpoint) {
   @if $breakpoint == sm {
-    @media (min-width: 576px) { @content; }
+    @media (min-width: 576px) {
+      @content;
+    }
   } @else if $breakpoint == md {
-    @media (min-width: 768px) { @content; }
+    @media (min-width: 768px) {
+      @content;
+    }
   } @else if $breakpoint == lg {
-    @media (min-width: 992px) { @content; }
+    @media (min-width: 992px) {
+      @content;
+    }
   } @else if $breakpoint == xl {
-    @media (min-width: 1200px) { @content; }
+    @media (min-width: 1200px) {
+      @content;
+    }
   }
 }
-

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -17,8 +17,9 @@ $color-inline-code-bg: #f8f9fa !default;
 $color-inline-code-border: #aaaaaa !default;
 
 // Typography
-$font-family-base: -apple-system, BlinkMacSystemFont, "Helvetica Neue",
-  "ヒラギノ角ゴ ProN W3", "Hiragino Kaku Gothic ProN", Arial, Meiryo, sans-serif !default;
+$font-family-base:
+  -apple-system, BlinkMacSystemFont, "Helvetica Neue", "ヒラギノ角ゴ ProN W3",
+  "Hiragino Kaku Gothic ProN", Arial, Meiryo, sans-serif !default;
 
 // Spacing scale
 $space-0: 0 !default;

--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -1,2 +1,1 @@
 // Button components (scaffold)
-

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -1,5 +1,5 @@
 // Code blocks and inline code
-@import '../variables';
+@import "../variables";
 
 pre {
   border: 0;
@@ -10,11 +10,20 @@ pre {
   color: $color-code-fg;
   overflow-x: auto;
   word-wrap: normal;
-  font-family: Consolas, Liberation Mono, Menlo, Courier, monospace;
+  font-family:
+    Consolas,
+    Liberation Mono,
+    Menlo,
+    Courier,
+    monospace;
 }
 
-p > code { font-size: 1rem; }
-pre > code { font-size: 0.875rem; }
+p > code {
+  font-size: 1rem;
+}
+pre > code {
+  font-size: 0.875rem;
+}
 
 p > code,
 ul li > code,
@@ -27,11 +36,17 @@ ol li > code {
 }
 
 @media (max-width: 767px) {
-  pre { border: 0; margin: 1rem -1rem; padding: 1rem; }
+  pre {
+    border: 0;
+    margin: 1rem -1rem;
+    padding: 1rem;
+  }
 }
 
 // Dark mode
-.dark pre { background-color: $color-code-bg; }
+.dark pre {
+  background-color: $color-code-bg;
+}
 
 // Inline code color tweak in dark mode (match inline contexts we style above)
 .dark p > code,

--- a/assets/scss/components/_content.scss
+++ b/assets/scss/components/_content.scss
@@ -5,9 +5,15 @@
 // (table styles reverted to main.scss)
 
 // Captions and alignment helpers
-.aligncenter { display: block; margin: 2rem auto; }
+.aligncenter {
+  display: block;
+  margin: 2rem auto;
+}
 
 @media (max-width: 767px) {
   .alignleft,
-  .alignright { display: block; margin: 2rem auto; }
+  .alignright {
+    display: block;
+    margin: 2rem auto;
+  }
 }

--- a/assets/scss/components/_typography.scss
+++ b/assets/scss/components/_typography.scss
@@ -11,7 +11,9 @@ h6 {
 }
 
 h1,
-h2 { font-size: 3.2rem; }
+h2 {
+  font-size: 3.2rem;
+}
 
 p,
 #breadcrumbs li {
@@ -25,15 +27,20 @@ article p {
   margin-bottom: 2rem;
 }
 
-article blockquote p { margin-bottom: 0; }
+article blockquote p {
+  margin-bottom: 0;
+}
 
 @media (max-width: 414px) {
-  h2 { font-size: 2rem; }
-  h3 { font-size: 1.75rem; }
+  h2 {
+    font-size: 2rem;
+  }
+  h3 {
+    font-size: 1.75rem;
+  }
 }
 
 a {
   color: var(--pochi-accent);
   text-decoration: none;
 }
-

--- a/assets/scss/layout/_grid.scss
+++ b/assets/scss/layout/_grid.scss
@@ -16,7 +16,9 @@
   margin-right: -1rem;
   margin-left: -1rem;
 }
-.row > * { max-width: 100%; }
+.row > * {
+  max-width: 100%;
+}
 
 // Columns
 #contents,
@@ -29,7 +31,9 @@
 
 // Base: stack
 .col-sm-4,
-.col-md-12 { width: 100%; }
+.col-md-12 {
+  width: 100%;
+}
 
 // Breakpoints
 @media (min-width: 576px) {
@@ -40,10 +44,23 @@
 }
 
 @media (min-width: 768px) {
-  .col-md-12 { flex: 0 0 auto; width: 100%; }
-  .col-md-9 { flex: 0 0 auto; width: 75%; }
-  .col-md-8 { flex: 0 0 auto; width: 66.66666667%; }
-  .col-md-4 { flex: 0 0 auto; width: 33.33333333%; }
-  .col-md-3 { width: 25%; }
+  .col-md-12 {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .col-md-9 {
+    flex: 0 0 auto;
+    width: 75%;
+  }
+  .col-md-8 {
+    flex: 0 0 auto;
+    width: 66.66666667%;
+  }
+  .col-md-4 {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .col-md-3 {
+    width: 25%;
+  }
 }
-

--- a/assets/scss/layout/_main-content.scss
+++ b/assets/scss/layout/_main-content.scss
@@ -16,4 +16,3 @@
     margin-top: 1rem;
   }
 }
-

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -9,17 +9,17 @@ Version: 0.1.1
 */
 
 // Design tokens and mixins (compat: @import for older Sass)
-@import 'variables';
-@import 'mixins';
+@import "variables";
+@import "mixins";
 
 // Project structure (progressively migrated)
-@import 'base';
-@import 'layout';
-@import 'components/buttons';
-@import 'components/nav';
-@import 'components/typography';
-@import 'components/code';
-@import 'utilities/helpers';
+@import "base";
+@import "layout";
+@import "components/buttons";
+@import "components/nav";
+@import "components/typography";
+@import "components/code";
+@import "utilities/helpers";
 
 // Legacy styles continue below
 
@@ -28,9 +28,9 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue",
-    "ヒラギノ角ゴ ProN W3", "Hiragino Kaku Gothic ProN", Arial, Meiryo,
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Helvetica Neue", "ヒラギノ角ゴ ProN W3",
+    "Hiragino Kaku Gothic ProN", Arial, Meiryo, sans-serif;
   font-weight: 300;
   color: var(--pochi-text);
   background-color: var(--pochi-surface-soft);
@@ -38,7 +38,11 @@ body {
   margin: 0;
 }
 
-@media (min-width: 0) { html { font-size: 14px; } }
+@media (min-width: 0) {
+  html {
+    font-size: 14px;
+  }
+}
 
 /* grid moved to layout/_grid.scss */
 
@@ -388,8 +392,9 @@ article,
 }
 
 .hero-caption h1 {
-  font-family: "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", Meiryo,
-    メイリオ, sans-serif;
+  font-family:
+    "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", Meiryo, メイリオ,
+    sans-serif;
   font-size: 3rem;
 }
 

--- a/assets/scss/reboot.scss
+++ b/assets/scss/reboot.scss
@@ -70,11 +70,13 @@
   --bs-dark-border-subtle: #adb5bd;
   --bs-white-rgb: 255, 255, 255;
   --bs-black-rgb: 0, 0, 0;
-  --bs-font-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  --bs-font-sans-serif:
+    system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans",
+    "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Noto Color Emoji";
+  --bs-font-monospace:
+    SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   --bs-gradient: linear-gradient(
     180deg,
     rgba(255, 255, 255, 0.15),

--- a/assets/scss/utilities/_helpers.scss
+++ b/assets/scss/utilities/_helpers.scss
@@ -1,5 +1,9 @@
 // Utilities (helpers, one-off classes). Keep tiny.
-@import '../mixins';
+@import "../mixins";
 
-.u-hidden { display: none !important; }
-.u-visually-hidden { @include sr-only; }
+.u-hidden {
+  display: none !important;
+}
+.u-visually-hidden {
+  @include sr-only;
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="{{ .Site.Language.Lang }}">
   {{ $pageType := "" }}
   {{ if .IsHome }}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -3,15 +3,18 @@
 {{ template "_internal/twitter_cards.html" . }}
 {{ partial "head/schema.html" . }}
 
+
 <script>
   (function () {
     try {
-      var pref = localStorage.getItem('pref-theme');
-      var isDark = pref ? pref === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var pref = localStorage.getItem("pref-theme");
+      var isDark = pref
+        ? pref === "dark"
+        : window.matchMedia("(prefers-color-scheme: dark)").matches;
       if (isDark) {
-        document.documentElement.classList.add('dark');
+        document.documentElement.classList.add("dark");
       } else {
-        document.documentElement.classList.remove('dark');
+        document.documentElement.classList.remove("dark");
       }
     } catch (e) {}
   })();

--- a/layouts/partials/molecules/comment.html
+++ b/layouts/partials/molecules/comment.html
@@ -1,10 +1,10 @@
 {{ if .Site.Params.comment.enable }}
-<div class="row">
-  <div class="col-md-12 comment-wrapper">
-    <div class="mymenu-thumb mymenu-related-list">
-      <h3>コメントを残す</h3>
-      {{ template "_internal/disqus.html" . }}
+  <div class="row">
+    <div class="col-md-12 comment-wrapper">
+      <div class="mymenu-thumb mymenu-related-list">
+        <h3>コメントを残す</h3>
+        {{ template "_internal/disqus.html" . }}
+      </div>
     </div>
   </div>
-</div>
 {{ end }}

--- a/layouts/partials/molecules/related_posts.html
+++ b/layouts/partials/molecules/related_posts.html
@@ -20,7 +20,9 @@
                   {{ .Title }}
                   <div class="post-info">
                     <div class="kiji-date">
-                      <time datetime="{{ .PublishDate.Local.Format "2006-01-02 15:04:05" }}">
+                      <time
+                        datetime="{{ .PublishDate.Local.Format "2006-01-02 15:04:05" }}"
+                      >
                         {{ partial "atoms/icon.html" (dict "id" "icon-pencil") }}
                         {{ .PublishDate.Local.Format "2006-01-02" }}
                       </time>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,30 +11,33 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@babel/types": "^7.26.5"
+        "@babel/types": "^7.28.2"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -44,13 +47,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -60,6 +64,7 @@
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/@fsouza/prettierd/-/prettierd-0.26.1.tgz",
       "integrity": "sha512-+UY6Zj2S4gVo58q1gSi5JAaeTmo33Qy4VZMFUC8pewJwwb16+EQMz1AZMXO6XR6vGUB5UlgKYakTkiSc9isFGw==",
+      "license": "ISC",
       "dependencies": {
         "core_d": "^6.1.0",
         "prettier": "^3.4.2"
@@ -76,6 +81,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -89,6 +95,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 8"
@@ -98,6 +105,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -107,10 +115,50 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
+      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.39.1",
+        "@typescript-eslint/types": "^8.39.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
+      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.20.0.tgz",
-      "integrity": "sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -121,19 +169,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.20.0.tgz",
-      "integrity": "sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0",
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -143,17 +194,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.20.0.tgz",
-      "integrity": "sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==",
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.39.1",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -167,12 +219,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -182,6 +236,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -191,17 +246,19 @@
       }
     },
     "node_modules/core_d": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/core_d/-/core_d-6.1.0.tgz",
-      "integrity": "sha512-vYgenhJ8CYCj+7LPbPdyFo2u0Doavfbi/vhFpR/BsW9/iUAhuKd+sw2l4CHXhaXIo4/058p2nlsAtbL7iswm5A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/core_d/-/core_d-6.1.1.tgz",
+      "integrity": "sha512-96Pba8AFV6AjBwOz0PxHXkKm4CzmrNA2Im8NlPCsi70OefzgXxw3VDuKIMC18SXV1GF2oyNfIdh3w+JaNkSCCA==",
+      "license": "MIT",
       "dependencies": {
         "supports-color": "^8.1.0"
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
@@ -216,9 +273,10 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -231,6 +289,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -244,9 +303,10 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -256,6 +316,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -268,6 +329,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -280,6 +342,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -288,6 +351,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -297,6 +361,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -309,6 +374,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.12.0"
@@ -318,6 +384,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">= 8"
@@ -327,6 +394,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -340,6 +408,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -355,12 +424,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=8.6"
@@ -388,6 +459,7 @@
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.15.tgz",
       "integrity": "sha512-WqU92E1NokWYNZ9mLE6ijoRg6LtIGdLMePt2C7UBDjXeDH9okcRI3zRqtnWR4s5AloiqyvZ66jNBAa9tmRY5EQ==",
+      "license": "MIT",
       "dependencies": {
         "ulid": "^2.3.0"
       },
@@ -416,12 +488,14 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "optional": true
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "iojs": ">=1.0.0",
@@ -446,15 +520,17 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -467,6 +543,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -481,6 +558,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-number": "^7.0.0"
@@ -490,9 +568,10 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=18.12"
@@ -502,9 +581,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "bin": {
@@ -516,9 +596,10 @@
       }
     },
     "node_modules/ulid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
-      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
       "bin": {
         "ulid": "bin/cli.js"
       }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "scripts": {
+    "format": "prettier . --write",
+    "format:check": "prettier . --check",
+    "lint": "prettier . --check",
+    "serve": "hugo serve -s example_site --themesDir .. -t pochi",
+    "build": "hugo --gc -s example_site --themesDir .. -t pochi"
+  },
   "dependencies": {
     "@fsouza/prettierd": "^0.26.1",
     "prettier": "^3.6.2",


### PR DESCRIPTION
Adds format/format:check/lint/serve/build scripts and extends Prettier parsing to SCSS/JS/YAML for consistent formatting.

Changes:
- Update package.json scripts (format, format:check, lint, serve, build)
- Extend .prettierrc overrides to scss/js/yml

Test:
- Ran 'npm run format:check' and 'npm run serve' successfully.

Impact:
- Developer experience only; no runtime impact on theme output.