### PR TITLE
refactor(styles): color tokenization, sidebar extraction, and docs update

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+layouts/_default/index.json
+layouts/_default/list.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,46 @@
 # Repository Guidelines
 
-This theme is a Hugo project focused on layouts and assets. Keep changes small, reversible, and consistent with existing patterns.
+This Hugo theme focuses on clean layouts and Hugo Pipes assets. Keep changes small, reversible, and consistent with existing patterns.
 
 ## Project Structure & Module Organization
 
 - `layouts/`: Hugo templates (Go templates). Includes `_default/`, `partials/`, and page-type layouts.
-- `assets/`: Source assets compiled by Hugo Pipes (CSS/SCSS, JS, images, icons).
+- `assets/`: Source assets compiled by Hugo Pipes (SCSS, JS, images, icons).
+  - SCSS: `assets/scss/` with `_variables.scss`, `_mixins.scss`, `layout/`, `components/`, `utilities/`, `main.scss`.
 - `example_site/`: Local preview content. Use it to test changes interactively.
 - `.github/`: CI and dependency tooling; update when workflows change.
 - `theme.toml`: Theme metadata; bump min Hugo version or tags when required.
 
 ## Build, Test, and Development Commands
 
-- Preview locally: `hugo serve -s example_site --themesDir .. -t pochi`
-  - Serves the example site with live reload.
-- Format check: `npx prettier . --check`
-- Auto-format: `npx prettier . --write`
-  - Uses `prettier-plugin-go-template` to format Go template HTML.
+- Preview locally: `npm run serve`
+  - Runs `hugo serve -s example_site --themesDir .. -t pochi` with live reload.
+- Build example site: `npm run build`
+- Format all files: `npm run format`
+- Format check (CI-friendly): `npm run format:check` (alias: `npm run lint`)
+  - Prettier targets HTML (Go template via plugin), SCSS, JS, YAML.
+  - After creating or editing code, run: `npm run format`.
 
 ## Coding Style & Naming Conventions
 
 - Indentation: 2 spaces; avoid tabs.
 - Templates: Prefer small, composable partials under `layouts/partials/`.
 - Naming: kebab-case for files (`post-card.html`), lowercase for asset files.
-- CSS/SCSS: Keep variables and mixins scoped; avoid global leaks.
+- CSS/SCSS: Prefer tokens in `_variables.scss`; use CSS variables and `:root.dark` for dark mode.
+  - Dark mode: toggle adds/removes `dark` class on `html` (not `body`).
 - JS: Keep DOM hooks prefixed (`data-pochi-*`) to prevent conflicts.
 
 ## Testing Guidelines
 
-- Manual testing via `hugo serve` on `example_site/` pages: home, posts, pagination, 404, robots.
+- Manual testing via `npm run serve` on `example_site/` pages: home, posts, pagination, 404, robots.
+- Verify theme toggle (`#theme-toggle-switch`) works; no FOUC on initial load.
 - Cross-browser smoke check for critical pages; verify no console errors.
 - No unit test suite at present; add reproducible steps in PRs for bug fixes.
 
 ## Commit & Pull Request Guidelines
 
 - Commits: Imperative mood, concise scope (e.g., `fix(list): correct ellipsis wrap`).
-- PRs: Clear description, before/after screenshots for UI, link issues (`#123`), and steps to verify.
+- PRs: Clear description, before/after screenshots for UI, link issues (`#123`), and steps to verify (include `npm run serve` steps).
 - Keep diffs focused; include migration notes if breaking template variables or CSS classes.
 
 ## Security & Configuration Tips

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -46,6 +46,8 @@ $shadow-2: 0 2px 8px rgba(0, 0, 0, 0.12) !default;
   --pochi-surface: #ffffff; // generic surface (light)
   --pochi-surface-soft: #{$color-bg};
   --pochi-link: #{$color-accent};
+  --pochi-on-accent: #ffffff; // text on accent backgrounds
+  --pochi-on-dark: #ffffff; // text on dark/imagery overlays
 }
 
 :root.dark {
@@ -59,4 +61,6 @@ $shadow-2: 0 2px 8px rgba(0, 0, 0, 0.12) !default;
   --pochi-border: #d8d8d8;
   --pochi-blockquote-bg: #212121;
   --pochi-link: #{$color-accent};
+  --pochi-on-accent: #ffffff;
+  --pochi-on-dark: #ffffff;
 }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -5,8 +5,7 @@ $color-text: #424242 !default;
 $color-bg: #f5f5f5 !default;
 $color-primary: #1a73e8 !default; // reserved
 $color-accent: #79c6b6 !default; // theme accent
-$color-border: #e0e0e0 !default;
-$color-border-light: #e9e9e9 !default;
+$color-border: #d8d8d8 !default;
 $color-card: #ffffff !default;
 $color-text-muted: #555555 !default;
 
@@ -41,7 +40,6 @@ $shadow-2: 0 2px 8px rgba(0, 0, 0, 0.12) !default;
   --pochi-primary: #{$color-primary};
   --pochi-accent: #{$color-accent};
   --pochi-border: #{$color-border};
-  --pochi-border-light: #{$color-border-light};
   --pochi-card: #{$color-card};
   --pochi-text-muted: #{$color-text-muted};
   --pochi-blockquote-bg: #{$color-bg};
@@ -58,8 +56,7 @@ $shadow-2: 0 2px 8px rgba(0, 0, 0, 0.12) !default;
   --pochi-card: #2f2f2f;
   --pochi-surface: #2f2f2f;
   --pochi-surface-soft: #1d1d1d;
-  --pochi-border: #2a2a2a;
-  --pochi-border-light: #3a3a3a;
+  --pochi-border: #d8d8d8;
   --pochi-blockquote-bg: #212121;
   --pochi-link: #{$color-accent};
 }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -41,6 +41,7 @@ $shadow-2: 0 2px 8px rgba(0, 0, 0, 0.12) !default;
   --pochi-primary: #{$color-primary};
   --pochi-accent: #{$color-accent};
   --pochi-border: #{$color-border};
+  --pochi-border-light: #{$color-border-light};
   --pochi-card: #{$color-card};
   --pochi-text-muted: #{$color-text-muted};
   --pochi-blockquote-bg: #{$color-bg};
@@ -58,6 +59,7 @@ $shadow-2: 0 2px 8px rgba(0, 0, 0, 0.12) !default;
   --pochi-surface: #2f2f2f;
   --pochi-surface-soft: #1d1d1d;
   --pochi-border: #2a2a2a;
+  --pochi-border-light: #3a3a3a;
   --pochi-blockquote-bg: #212121;
   --pochi-link: #{$color-accent};
 }

--- a/assets/scss/components/_nav.scss
+++ b/assets/scss/components/_nav.scss
@@ -118,7 +118,7 @@ header ul li .collapsible .collapsible-body {
   visibility: hidden;
   top: 90%;
   width: auto;
-  background-color: #fff;
+  background-color: var(--pochi-card);
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   z-index: 1;
   -webkit-transition: all 0.2s ease-in-out 0s;

--- a/assets/scss/components/_nav.scss
+++ b/assets/scss/components/_nav.scss
@@ -72,7 +72,7 @@ nav ul li a {
 }
 
 nav ul > li:hover > a {
-  color: #fff;
+  color: var(--pochi-on-accent);
   background-color: var(--pochi-accent);
 }
 

--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -1,0 +1,75 @@
+// Sidebar-specific styles (extracted from main.scss)
+
+#sidebar aside:last-child {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 5.5rem;
+  margin-bottom: 3rem;
+}
+
+#sidebar .table-of-contents {
+  background-color: var(--pochi-card);
+  border: none;
+  max-height: 86vh;
+  overflow-y: auto;
+}
+
+#sidebar .table-of-contents p {
+  margin-top: 1rem;
+}
+
+#sidebar aside {
+  margin-bottom: 2rem;
+}
+
+#sidebar a {
+  color: var(--pochi-text-muted);
+}
+#sidebar a:hover {
+  color: var(--pochi-accent);
+}
+
+#sidebar .profile-flex-box {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+  justify-content: space-around;
+}
+
+#sidebar #profile-image {
+  float: left;
+  height: 30%;
+  width: 30%;
+  background-color: var(--pochi-card);
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+#sidebar .tagcloud a {
+  background-color: var(--pochi-card);
+  color: var(--pochi-text-muted);
+  font-size: 0.75rem !important;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 0.5rem;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  display: inline-block;
+  border-radius: 2px;
+}
+
+#sidebar .tagcloud a:hover {
+  background-color: var(--pochi-accent);
+  color: #fff;
+}
+
+@media (max-width: 767px) {
+  #sidebar {
+    margin-left: 0rem;
+  }
+}

--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -65,7 +65,7 @@
 
 #sidebar .tagcloud a:hover {
   background-color: var(--pochi-accent);
-  color: #fff;
+  color: var(--pochi-on-accent);
 }
 
 @media (max-width: 767px) {

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1069,6 +1069,12 @@ iframe {
   overflow: hidden;
 }
 
+/* input */
+input.form-control {
+  color: var(--pochi-text);
+  font-weight: 300;
+}
+
 /* dark mode */
 .dark article,
 .dark .comments,

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -99,8 +99,8 @@ strong {
 /* -----Color----- */
 .btn-primary,
 .btn-secondary {
-  color: #555;
-  background-color: #fff;
+  color: var(--pochi-text-muted);
+  background-color: var(--pochi-card);
   border: none;
 }
 
@@ -461,7 +461,7 @@ article,
 /* article-list moved to components/_cards.scss */
 .article-list .post-row {
   margin: 0 0 3rem 0;
-  background-color: #fff;
+  background-color: var(--pochi-card);
   border-radius: 0.25rem;
 }
 
@@ -483,7 +483,7 @@ article,
 }
 
 .article-list .post-excerpt {
-  color: #555;
+  color: var(--pochi-text-muted);
 }
 
 .article-list a h2,
@@ -504,7 +504,7 @@ article,
   padding: 0;
   margin: 1rem 0;
   display: block;
-  color: #555;
+  color: var(--pochi-text-muted);
   font-size: 0.75rem;
   overflow: hidden;
 }
@@ -518,7 +518,7 @@ article,
 }
 
 .more-btn {
-  border: 1px solid #e9e9e9;
+  border: 1px solid var(--pochi-border-light);
   border-radius: 0.25rem;
   text-transform: uppercase;
   font-size: 1rem;
@@ -553,7 +553,7 @@ article,
 .table-of-contents {
   margin-top: 3rem;
   padding: 0.5rem 0 1rem;
-  border: 1px solid #d8d8d8;
+  border: 1px solid var(--pochi-border);
   border-radius: 0.25rem;
 }
 
@@ -586,7 +586,7 @@ article,
 }
 
 .table-of-contents p span {
-  background: #fff;
+  background: var(--pochi-card);
   padding: 0 10px;
   position: relative;
   z-index: 5;
@@ -608,7 +608,7 @@ article,
 .table-of-contents ol li a {
   position: relative;
   display: inline-block;
-  color: #555;
+  color: var(--pochi-text-muted);
 }
 
 .table-of-contents ol li a:hover {
@@ -631,7 +631,7 @@ article,
 }
 
 #sidebar .table-of-contents {
-  background-color: #fff;
+  background-color: var(--pochi-card);
   border: none;
   max-height: 86vh;
   overflow-y: auto;
@@ -659,8 +659,8 @@ article,
 .pagination-index .pagination .page-item .page-link {
   border: none;
   border-radius: 0.25rem;
-  color: #555;
-  background-color: #fff;
+  color: var(--pochi-text-muted);
+  background-color: var(--pochi-card);
   padding: 0.5rem 0.75rem;
 }
 
@@ -670,8 +670,8 @@ article,
 }
 
 .pagination-index .pagination .page-item.active .page-link {
-  color: #555;
-  background-color: #f5f5f5;
+  color: var(--pochi-text-muted);
+  background-color: var(--pochi-bg);
   pointer-events: none;
 }
 
@@ -693,21 +693,21 @@ footer .copyright {
 }
 
 footer.footer-section {
-  background-color: #fff;
+  background-color: var(--pochi-card);
 }
 
 footer p.copyright {
   display: inline-block;
   overflow: inherit;
-  color: #555;
+  color: var(--pochi-text-muted);
   padding-right: 0.5rem;
 }
 
 footer .copyright a {
   display: inline-block;
   overflow: inherit;
-  color: #555;
-  border-bottom: 1px solid #555;
+  color: var(--pochi-text-muted);
+  border-bottom: 1px solid var(--pochi-border);
 }
 
 footer .copyright a:hover {
@@ -754,14 +754,14 @@ footer h2:before {
 
 #sidebar h2 span,
 footer h2 span {
-  background: #f5f5f5;
+  background: var(--pochi-bg);
   padding: 0 10px;
   position: relative;
   z-index: 5;
 }
 
 footer h2 span {
-  background-color: #d9d9d9;
+  background-color: var(--pochi-surface-soft);
 }
 
 #sidebar .row {
@@ -784,7 +784,7 @@ footer ul {
 }
 
 #sidebar a {
-  color: #555;
+  color: var(--pochi-text-muted);
 }
 
 #sidebar a:hover {
@@ -807,7 +807,7 @@ footer ul {
   float: left;
   height: 30%;
   width: 30%;
-  background-color: #fff;
+  background-color: var(--pochi-card);
   border-radius: 50%;
   overflow: hidden;
 }
@@ -825,9 +825,9 @@ footer ul {
 
 /* ----- Tagcloud ----- */
 #sidebar .tagcloud a {
-  background-color: #fff;
+  background-color: var(--pochi-card);
   /* color: #79c6b6; */
-  color: #555;
+  color: var(--pochi-text-muted);
   font-size: 0.75rem !important;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -891,7 +891,7 @@ footer ul {
 article,
 .comments,
 .mymenu-related-list {
-  background-color: #fff;
+  background-color: var(--pochi-card);
   border-radius: 0.25rem;
   padding: 3rem;
   margin-bottom: 3rem;
@@ -910,7 +910,7 @@ article .kiji-tag li {
 
 article .kiji-tag li a {
   display: inline-block;
-  color: #555555;
+  color: var(--pochi-text-muted);
   font-size: 0.75rem !important;
   letter-spacing: 1px;
   text-transform: uppercase;
@@ -986,7 +986,7 @@ table {
 
 blockquote {
   border-left: 5px solid #79c6b6;
-  background-color: #f5f5f5;
+  background-color: var(--pochi-bg);
   padding: 2rem;
   margin: 3rem 0;
   font-style: italic;
@@ -1119,7 +1119,7 @@ article .featured-image-wrapper {
 
 /* ----- Comments----- */
 .btn-primary {
-  color: #555;
+  color: var(--pochi-text-muted);
   text-transform: uppercase;
   font-size: 1rem;
   padding: 7px 16px 8px;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -97,7 +97,7 @@ strong {
 #scroll-to-top {
   background-color: var(--pochi-accent);
   border-color: var(--pochi-accent);
-  color: #fff;
+  color: var(--pochi-on-accent);
 }
 
 .input-group {
@@ -362,7 +362,7 @@ article,
 .hero-caption {
   text-align: center;
   width: 100%;
-  color: #fff;
+  color: var(--pochi-on-dark);
   text-shadow: 0 0 7px #000;
   font-weight: bold;
   font-family:
@@ -404,7 +404,7 @@ article,
     text-align: left;
     margin: 0;
   }
-
+}
 
 /* -----Breadcrumb----- */
 #breadcrumbs {
@@ -609,7 +609,7 @@ article,
 
 .pagination-index .pagination .page-item .page-link:hover {
   background-color: var(--pochi-accent);
-  color: #fff;
+  color: var(--pochi-on-accent);
 }
 
 .pagination-index .pagination .page-item.active .page-link {
@@ -795,7 +795,7 @@ article .kiji-tag li a {
 article .kiji-tag li a:hover {
   background-color: var(--pochi-accent);
   border-color: var(--pochi-accent);
-  color: #fff;
+  color: var(--pochi-on-accent);
 }
 
 article .post-info {
@@ -1037,7 +1037,7 @@ iframe {
   width: 100%;
   height: 100%;
   display: inline-block;
-  color: #fff;
+  color: var(--pochi-on-accent);
 }
 
 #scroll-to-top.fade-in {
@@ -1117,7 +1117,7 @@ iframe {
 .dark .pagination-index .pagination .page-item .page-link:hover,
 .dark #sidebar .tagcloud a:hover {
   background-color: var(--pochi-accent);
-  color: #fff;
+  color: var(--pochi-on-accent);
 }
 
 .dark .article-list a:hover h2,

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -17,6 +17,7 @@ Version: 0.1.1
 @import "layout";
 @import "components/buttons";
 @import "components/nav";
+@import "components/sidebar";
 @import "components/typography";
 @import "components/code";
 @import "utilities/helpers";
@@ -44,13 +45,10 @@ body {
   }
 }
 
-/* grid moved to layout/_grid.scss */
-
 @media (min-width: 768px) {
   html {
     font-size: 14.5px;
   }
-  /* grid moved to layout/_grid.scss */
 }
 
 @media (min-width: 1200px) {
@@ -59,17 +57,11 @@ body {
   }
 }
 
-/* grid moved to layout/_grid.scss */
-
 mark {
   border-radius: 0.25rem;
 }
 
-/* container moved to layout/_grid.scss */
-
 /* -----Font----- */
-/* typography moved to components/_typography.scss */
-
 .button-collapse {
   color: #26a69a;
 }
@@ -83,10 +75,6 @@ article p {
 article blockquote p {
   margin-bottom: 0;
 }
-
-/* typography responsive moved */
-
-/* link styles moved to components/_typography.scss */
 
 a:hover {
   text-decoration: none;
@@ -107,8 +95,8 @@ strong {
 .btn-primary:hover,
 .btn-secondary:hover,
 #scroll-to-top {
-  background-color: #79c6b6;
-  border-color: #79c6b6;
+  background-color: var(--pochi-accent);
+  border-color: var(--pochi-accent);
   color: #fff;
 }
 
@@ -270,8 +258,6 @@ article,
     0 3px 1px -2px rgba(0, 0, 0, 0.2);
 }
 
-/* nav elevation moved to components/_nav.scss */
-
 .article-list .post-row:hover {
   box-shadow:
     0 8px 17px 2px rgba(0, 0, 0, 0.14),
@@ -283,8 +269,6 @@ article,
 #scroll-to-top.fade-in:hover {
   opacity: 0.8;
 }
-
-/* navbar moved to components/_nav.scss */
 
 /* -----Image-wrapper----- */
 .image-wrapper {
@@ -370,8 +354,6 @@ article,
   filter: brightness(0.8);
 }
 
-/* main-content moved to layout/_main-content.scss */
-
 #parallax-object {
   z-index: 1;
   position: absolute;
@@ -423,8 +405,6 @@ article,
     margin: 0;
   }
 
-  /* main-content.margin-top responsive moved to layout/_main-content.scss */
-}
 
 /* -----Breadcrumb----- */
 #breadcrumbs {
@@ -458,7 +438,6 @@ article,
   margin-bottom: 2rem;
 }
 
-/* article-list moved to components/_cards.scss */
 .article-list .post-row {
   margin: 0 0 3rem 0;
   background-color: var(--pochi-card);
@@ -496,7 +475,7 @@ article,
 
 .article-list a:hover h2,
 .mymenu-related a:hover .text {
-  color: #79c6b6;
+  color: var(--pochi-accent);
 }
 
 .article-list .post-info,
@@ -511,31 +490,6 @@ article,
 
 .article-list p {
   margin: 0;
-}
-
-.more-btn-wrapper {
-  text-align: right;
-}
-
-.more-btn {
-  border: 1px solid var(--pochi-border-light);
-  border-radius: 0.25rem;
-  text-transform: uppercase;
-  font-size: 1rem;
-  padding: 0.5rem 1rem 0.5rem;
-  display: inline-block;
-  margin-top: 1rem;
-  -o-transition: 0.3s;
-  -ms-transition: 0.3s;
-  -moz-transition: 0.3s;
-  -webkit-transition: 0.3s;
-  transition: 0.3s;
-}
-
-.more-btn:hover {
-  border-color: #79c6b6;
-  background-color: #79c6b6;
-  color: #fff;
 }
 
 @media (max-width: 767px) {
@@ -612,7 +566,7 @@ article,
 }
 
 .table-of-contents ol li a:hover {
-  color: #79c6b6;
+  color: var(--pochi-accent);
 }
 
 .table-of-contents ol li a:after {
@@ -623,22 +577,11 @@ article,
   left: 0;
   width: 0;
   height: 1px;
-  background-color: #79c6b6;
+  background-color: var(--pochi-accent);
 }
 
 .table-of-contents ol li a:hover:after {
   width: 100%;
-}
-
-#sidebar .table-of-contents {
-  background-color: var(--pochi-card);
-  border: none;
-  max-height: 86vh;
-  overflow-y: auto;
-}
-
-#sidebar .table-of-contents p {
-  margin-top: 1rem;
 }
 
 /* -----page-nation----- */
@@ -665,7 +608,7 @@ article,
 }
 
 .pagination-index .pagination .page-item .page-link:hover {
-  background-color: #79c6b6;
+  background-color: var(--pochi-accent);
   color: #fff;
 }
 
@@ -711,15 +654,7 @@ footer .copyright a {
 }
 
 footer .copyright a:hover {
-  color: #79c6b6;
-}
-
-/*----- Sidebar -----*/
-#sidebar aside:last-child {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 5.5rem;
-  margin-bottom: 3rem;
+  color: var(--pochi-accent);
 }
 
 #sidebar h2,
@@ -764,10 +699,6 @@ footer h2 span {
   background-color: var(--pochi-surface-soft);
 }
 
-#sidebar .row {
-  margin-bottom: 2rem;
-}
-
 #sidebar p,
 footer p {
   font-size: 0.9rem;
@@ -779,68 +710,9 @@ footer ul {
   font-size: 0.9rem;
 }
 
-#sidebar aside {
-  margin-bottom: 2rem;
-}
-
-#sidebar a {
-  color: var(--pochi-text-muted);
-}
-
-#sidebar a:hover {
-  color: #79c6b6;
-}
-
-#sidebar .profile-flex-box {
-  display: -webkit-box;
-  display: -moz-box;
-  display: -ms-flexbox;
-  display: -webkit-flex;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  justify-content: space-around;
-}
-
-#sidebar #profile-image {
-  float: left;
-  height: 30%;
-  width: 30%;
-  background-color: var(--pochi-card);
-  border-radius: 50%;
-  overflow: hidden;
-}
-
-@media (max-width: 767px) {
-  #sidebar {
-    margin-left: 0rem;
-  }
-}
-
 /* ----- Contact form ----- */
 .required {
   color: #ed929f;
-}
-
-/* ----- Tagcloud ----- */
-#sidebar .tagcloud a {
-  background-color: var(--pochi-card);
-  /* color: #79c6b6; */
-  color: var(--pochi-text-muted);
-  font-size: 0.75rem !important;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  padding: 0.5rem;
-  margin-right: 0.5rem;
-  margin-bottom: 0.5rem;
-  display: inline-block;
-  border-radius: 2px;
-}
-
-#sidebar .tagcloud a:hover {
-  background-color: #79c6b6;
-  color: #fff;
 }
 
 /* ----- Categories ----- */
@@ -921,14 +793,14 @@ article .kiji-tag li a {
 }
 
 article .kiji-tag li a:hover {
-  background-color: #79c6b6;
-  border-color: #79c6b6;
+  background-color: var(--pochi-accent);
+  border-color: var(--pochi-accent);
   color: #fff;
 }
 
 article .post-info {
   font-size: 0.9rem;
-  margin: 1rem 0;
+  margin: 1rem 0 3rem;
 }
 
 article .icatch {
@@ -951,15 +823,15 @@ article h2 {
   padding-right: 3rem;
   padding-left: 0.5rem;
   position: relative;
-  border-bottom: 1px solid #79c6b6;
-  border-left: 5px solid #79c6b6;
+  border-bottom: 1px solid var(--pochi-accent);
+  border-left: 5px solid var(--pochi-accent);
 }
 
 article h3 {
   font-size: 1.75rem;
   margin: 3rem 0;
   padding-left: 5px;
-  border-bottom: 1px solid #79c6b6;
+  border-bottom: 1px solid var(--pochi-accent);
 }
 
 article h4,
@@ -968,7 +840,7 @@ article h6 {
   font-size: 1.2rem;
   margin: 3rem 0 2rem 0;
   padding-left: 0.5rem;
-  border-left: 4px solid #79c6b6;
+  border-left: 4px solid var(--pochi-accent);
 }
 
 thead,
@@ -985,7 +857,7 @@ table {
 }
 
 blockquote {
-  border-left: 5px solid #79c6b6;
+  border-left: 5px solid var(--pochi-accent);
   background-color: var(--pochi-bg);
   padding: 2rem;
   margin: 3rem 0;
@@ -996,11 +868,7 @@ blockquote cite {
   font-size: 0.85rem;
 }
 
-/* captions moved to components/_content.scss */
-
 @media (max-width: 767px) {
-  /* caption responsive moved */
-
   article,
   .comments,
   .mymenu-related-list {
@@ -1065,8 +933,6 @@ picture {
 article .featured-image-wrapper {
   margin: 0 0 3rem;
 }
-
-/* code styles moved to components/_code.scss */
 
 /* -----Related post----- */
 .mymenu-related-list .row {
@@ -1250,13 +1116,13 @@ iframe {
 .dark .btn-secondary:hover,
 .dark .pagination-index .pagination .page-item .page-link:hover,
 .dark #sidebar .tagcloud a:hover {
-  background-color: #79c6b6;
+  background-color: var(--pochi-accent);
   color: #fff;
 }
 
 .dark .article-list a:hover h2,
 .dark .mymenu-related a:hover .text {
-  color: #79c6b6;
+  color: var(--pochi-accent);
 }
 
 .dark #side-nav,
@@ -1285,7 +1151,7 @@ iframe {
 }
 
 .dark .article-list .post-row:hover {
-  border-color: #79c6b6;
+  border-color: var(--pochi-accent);
   box-shadow:
     0 8px 17px 2px rgba(121, 198, 182, 0.34),
     0 3px 14px 2px rgba(121, 198, 182, 0.32),

--- a/assets/scss/reboot.scss
+++ b/assets/scss/reboot.scss
@@ -88,7 +88,7 @@
   --bs-body-line-height: 1.5;
   --bs-body-color: #212529;
   --bs-body-color-rgb: 33, 37, 41;
-  --bs-body-bg: var(--pochi-surface);
+  --bs-body-bg: #fff;
   --bs-body-bg-rgb: 255, 255, 255;
   --bs-emphasis-color: #000;
   --bs-emphasis-color-rgb: 0, 0, 0;

--- a/assets/scss/reboot.scss
+++ b/assets/scss/reboot.scss
@@ -88,7 +88,7 @@
   --bs-body-line-height: 1.5;
   --bs-body-color: #212529;
   --bs-body-color-rgb: 33, 37, 41;
-  --bs-body-bg: #fff;
+  --bs-body-bg: var(--pochi-surface);
   --bs-body-bg-rgb: 255, 255, 255;
   --bs-emphasis-color: #000;
   --bs-emphasis-color-rgb: 0, 0, 0;


### PR DESCRIPTION
## 概要
- カラーのトークン化（中立色＋アクセント）とテキストカラーの整理（on-accent / on-dark）
- サイドバーのスタイルを components/_sidebar.scss に抽出（等価移動・見た目変更なし）
- 使われていない `.more-btn` と border-light 系トークンを削除
- AGENTS.md 更新（開発コマンドと運用方針の明記）／`.prettierignore` 追加
- reboot.scss は変更なし（以前の試行は revert 済み）

## 変更詳細
- 中立色の置換:
  - `#fff/#555/#d8d8d8/#e9e9e9/#f5f5f5` → `var(--pochi-card / --pochi-text-muted / --pochi-border / --pochi-bg)`
- アクセント色の置換:
  - `#79c6b6` → `var(--pochi-accent)`（見出しボーダー、hover、ボタン、ページネーション、TOC 下線 など）
- テキスト色の追加トークン:
  - `--pochi-on-accent`（アクセント背景上の文字色）、`--pochi-on-dark`（ダーク背景/画像上の文字色）
- サイドバー:
  - `#sidebar` 配下を `assets/scss/components/_sidebar.scss` へ移動（sticky、リンク、TOC、タグクラウド、モバイル余白）

## 互換性 / 移行
- `.more-btn` は削除（未使用のため）。下流で参照している場合はご注意ください。
- `body.dark` は非推奨。`html.dark`（:root.dark）＋CSS変数での切り替えに統一。

## 動作確認
- `npm run serve`（example_site）で以下を確認:
  - ホーム/記事/カテゴリ/404 の描画に差分なし
  - テーマ切替（`#theme-toggle-switch`）が機能し、FOUCなし・コンソールエラーなし
  - サイドバー表示/TOC/タグクラウド hover などが従来どおり

## メンテナンス
- 変更や追記の後は `npm run format` を実行して整形をお願いします

## スコープ外
- reboot.scss のベース色変更は見送り（revert 済み）
