### PR TITLE
feat(nav): PJAX navigation with prefetch, hero/breadcrumbs swap, and instant scroll

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -15,7 +15,7 @@ function smoothScroll() {
     if (!href || href.charAt(0) !== "#") return;
     event.preventDefault();
     if (href === "#top") {
-      window.scrollTo({ top: 0, behavior: "smooth" });
+      window.scrollTo({ top: 0, behavior: "instant" });
     } else {
       const targetEl = document.querySelector(href);
       scrollToTarget(targetEl);

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1,0 +1,226 @@
+// Lightweight PJAX-style navigation with prefetch and View Transitions
+// - Prefetch internal links on hover/touch
+// - Intercept clicks to replace only the main content area
+// - Update history and document title
+// - Re-run page-level initializers from main.js (buildTableOfContents, initSearch)
+
+(function () {
+  const CACHE = new Map(); // url -> Promise<string> (HTML)
+  // Feature toggle: set to true to enable View Transitions animations
+  const ENABLE_VIEW_TRANSITIONS = false;
+  const SUPPORTS_VT =
+    ENABLE_VIEW_TRANSITIONS &&
+    typeof document.startViewTransition === "function";
+
+  function isInternalLink(a) {
+    if (!a || !a.href) return false;
+    if (a.target && a.target !== "") return false;
+    const url = new URL(a.href, location.href);
+    if (url.origin !== location.origin) return false;
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    if (url.href === location.href) return false;
+    if (url.hash && url.pathname === location.pathname) return false; // in-page anchor
+    const rel = (a.getAttribute("rel") || "").toLowerCase();
+    if (rel.includes("external") || rel.includes("nofollow")) return false;
+    const download = a.hasAttribute("download");
+    if (download) return false;
+    const href = a.getAttribute("href") || "";
+    if (href.startsWith("#")) return false;
+    if (/^(mailto:|tel:|javascript:)/i.test(href)) return false;
+    return true;
+  }
+
+  function fetchHTML(url) {
+    const key = typeof url === "string" ? url : url.href;
+    if (CACHE.has(key)) return CACHE.get(key);
+    const p = fetch(key, { credentials: "same-origin" })
+      .then((res) => {
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.text();
+      })
+      .catch((err) => {
+        // On failure, ensure cache does not poison next attempts
+        CACHE.delete(key);
+        throw err;
+      });
+    CACHE.set(key, p);
+    return p;
+  }
+
+  function parseHTML(html) {
+    const parser = new DOMParser();
+    return parser.parseFromString(html, "text/html");
+  }
+
+  function forceInstantScrollToTop() {
+    // Bypass any CSS `scroll-behavior: smooth` and force immediate jump
+    const el = document.scrollingElement || document.documentElement;
+    const prev = el.style.scrollBehavior;
+    el.style.scrollBehavior = "auto";
+    el.scrollTop = 0;
+    // Safari fallback
+    if (document.body) document.body.scrollTop = 0;
+    // Restore previous inline style on next frame
+    requestAnimationFrame(() => {
+      el.style.scrollBehavior = prev || "";
+    });
+  }
+
+  function getNextMain(doc) {
+    // Theme uses .main-content as the primary content wrapper
+    return doc.querySelector(".main-content");
+  }
+
+  function getNextHero(doc) {
+    // Single pages may render hero before main-content
+    return doc.querySelector(".parallax-container");
+  }
+
+  function getNextBreadcrumbsInfo(doc, nextMain) {
+    // Returns { el, container, external } or null
+    const crumb = doc.querySelector("#breadcrumbs");
+    if (!crumb) return null;
+    const external = nextMain ? !nextMain.contains(crumb) : true;
+    const container = crumb.closest(".container-fluid") || crumb;
+    return { el: crumb, container, external };
+  }
+
+  function swapContent(nextDoc, options) {
+    const nextMain = getNextMain(nextDoc);
+    const currentMain = document.querySelector(".main-content");
+    if (!nextMain || !currentMain) return false;
+
+    const nextHero = getNextHero(nextDoc);
+    const currentHero = document.querySelector(".parallax-container");
+
+    const nextCrumbsInfo = getNextBreadcrumbsInfo(nextDoc, nextMain);
+    const currentCrumbEl = document.querySelector("#breadcrumbs");
+    const currentCrumbsExternal =
+      currentCrumbEl && currentMain
+        ? !currentMain.contains(currentCrumbEl)
+        : false;
+    const currentCrumbsContainer = currentCrumbEl
+      ? currentCrumbEl.closest(".container-fluid") || currentCrumbEl
+      : null;
+
+    const doSwap = () => {
+      // Swap/insert/remove hero first to keep order stable
+      if (nextHero) {
+        const nextHeroNode = nextHero.cloneNode(true);
+        if (currentHero) {
+          currentHero.replaceWith(nextHeroNode);
+        } else {
+          currentMain.parentElement.insertBefore(nextHeroNode, currentMain);
+        }
+      } else if (currentHero) {
+        currentHero.remove();
+      }
+
+      // Breadcrumbs handling:
+      // - If current has external breadcrumbs, remove them first to avoid duplicates
+      if (currentCrumbsExternal && currentCrumbsContainer) {
+        currentCrumbsContainer.remove();
+      }
+      // - If next requires external breadcrumbs (i.e., not inside nextMain), insert before currentMain
+      if (nextCrumbsInfo && nextCrumbsInfo.external) {
+        const nextCrumbsNode = nextCrumbsInfo.container.cloneNode(true);
+        currentMain.parentElement.insertBefore(nextCrumbsNode, currentMain);
+      }
+
+      // Then swap the main content
+      const nextNode = nextMain.cloneNode(true);
+      currentMain.replaceWith(nextNode);
+
+      if (!options || options.scroll !== "preserve") {
+        forceInstantScrollToTop();
+      }
+    };
+
+    if (SUPPORTS_VT) {
+      document.startViewTransition(doSwap);
+    } else {
+      doSwap();
+    }
+
+    return true;
+  }
+
+  function afterSwapInit() {
+    try {
+      // Functions declared in assets/js/main.js are global in classic scripts
+      if (typeof buildTableOfContents === "function") buildTableOfContents();
+      if (typeof initSearch === "function") initSearch();
+      // Other global listeners (smoothScroll, toggleSideNav, theme) use document-level
+      // delegation and remain active across swaps.
+    } catch (_) {}
+  }
+
+  async function navigateTo(url, opts) {
+    try {
+      const html = await fetchHTML(url);
+      const doc = parseHTML(html);
+      const ok = swapContent(doc, opts);
+      if (!ok) throw new Error("Swap failed");
+      // Update title
+      const newTitle = doc.title;
+      if (newTitle) document.title = newTitle;
+      // Update history
+      const href = typeof url === "string" ? url : url.href;
+      if (!opts || opts.updateHistory !== false) {
+        history.pushState({}, "", href);
+      }
+      afterSwapInit();
+    } catch (e) {
+      // Fallback to full navigation on error
+      const href = typeof url === "string" ? url : url.href;
+      window.location.href = href;
+    }
+  }
+
+  // Prefetch on hover/touchstart
+  function setupPrefetching() {
+    const handler = (e) => {
+      const a = e.target && e.target.closest ? e.target.closest("a") : null;
+      if (!a) return;
+      if (!isInternalLink(a)) return;
+      // Avoid overfetching pagination hover storms by slight delay
+      const url = new URL(a.href, location.href);
+      setTimeout(() => fetchHTML(url.href).catch(() => {}), 40);
+    };
+    document.addEventListener("mouseover", handler, { passive: true });
+    document.addEventListener("touchstart", handler, { passive: true });
+  }
+
+  function setupClickNavigation() {
+    document.addEventListener("click", (e) => {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return; // left click only
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const a = e.target && e.target.closest ? e.target.closest("a") : null;
+      if (!a) return;
+      if (!isInternalLink(a)) return;
+      e.preventDefault();
+      const url = new URL(a.href, location.href);
+      navigateTo(url.href);
+    });
+  }
+
+  function setupPopState() {
+    window.addEventListener("popstate", () => {
+      // On back/forward, load and replace without pushing history again
+      navigateTo(location.href, { updateHistory: false, scroll: "preserve" });
+    });
+  }
+
+  function init() {
+    setupPrefetching();
+    setupClickNavigation();
+    setupPopState();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/layouts/partials/core/resources_js.html
+++ b/layouts/partials/core/resources_js.html
@@ -1,2 +1,4 @@
 {{ $js := resources.Get "js/main.js" | resources.Minify | fingerprint }}
 <script defer src="{{ $js.RelPermalink }}"></script>
+{{ $nav := resources.Get "js/navigation.js" | resources.Minify | fingerprint }}
+<script defer src="{{ $nav.RelPermalink }}"></script>


### PR DESCRIPTION
## Summary
Implements fast SPA-like navigation for the theme without turning it into a full SPA. Internal link clicks are intercepted to fetch the next page, then the page swaps only the relevant DOM regions. This yields much faster perceived navigation while keeping SEO and initial paint from Hugo intact.

## Changes
- Add lightweight PJAX-style nav with link prefetch
  - Intercepts internal links, fetches HTML, swaps content
  - Updates document title and history (back/forward supported)
- Swap targets expanded:
  -  (hero) is replaced/inserted/removed alongside content
  - Breadcrumbs before  are handled to avoid duplication
- Instant transitions by default:
  - Disables View Transitions animations (feature flag present for future use)
  - Forces instant scroll-to-top on navigation (bypasses CSS smooth scrolling)
- Keeps existing global listeners (theme toggle, side nav, smoothScroll)
  - Re-initializes TOC and search after swaps

## Files
- New: 
- Updated:  (add navigation bundle)

## Why
- Perceived performance: reduces full page reloads and preserves layout shell
- No framework dependency: uses plain JS + Hugo Pipes
- Progressive enhancement: falls back to full reload on errors or unsupported cases

## Verification
1. Run 
> serve
> hugo serve -s example_site --themesDir .. -t pochi
2. Navigate between list and single pages:
   - Observe fast content swaps without full reload
   - Hero () updates/appears/disappears correctly
   - Breadcrumbs only appear when expected (no duplication on list else-branch)
3. Use browser back/forward: content swaps and URL updates correctly
4. Confirm TOC and search re-initialize on single and search pages
5. Confirm there is no navigation animation (instant swap + scroll)

## Notes
- Meta tags and structured data are not dynamically updated (out of scope here)
- View Transitions animation can be re-enabled by toggling 
