### PR TITLE
feat(nav): add side-nav close button and close-on-link behavior

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -64,6 +64,28 @@ function toggleSideNav() {
       sideNavOverlay = document.querySelector("#side-nav-overlay");
     }
 
+    // Close the side nav when a link inside it is clicked
+    const linkInsideSideNav = event.target.closest
+      ? event.target.closest("#side-nav a")
+      : null;
+    // Close when the explicit close button is clicked
+    const closeBtn = event.target.closest
+      ? event.target.closest("#side-nav-close")
+      : null;
+    if (isSideNavOpen && (linkInsideSideNav || closeBtn)) {
+      isSideNavOpen = false;
+      sideNav.style.cssText = `
+        opacity: 0;
+      `;
+      sideNav.classList.remove(isActiveClass);
+      if (sideNavOverlay) {
+        sideNavOverlay.style.opacity = "0";
+        setTimeout(() => sideNavOverlay && sideNavOverlay.remove(), 300);
+      }
+      // Do not prevent default; navigation.js or browser will handle navigation
+      return;
+    }
+
     if (isSideNavOpen && event.target === sideNavOverlay) {
       isSideNavOpen = false;
       sideNav.style.cssText = `

--- a/assets/scss/components/_nav.scss
+++ b/assets/scss/components/_nav.scss
@@ -196,6 +196,62 @@ header ul li .collapsible .collapsible-body {
   padding: 0 2rem;
 }
 
+/* Side nav header (contains close button) */
+#side-nav .side-nav-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0.75rem 0.75rem;
+  background-color: var(--pochi-bg);
+  border-bottom: 1px solid var(--pochi-border);
+}
+
+#side-nav-close {
+  -webkit-appearance: none;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  height: 36px;
+  padding: 0 10px 0 40px; /* room for the X icon */
+  border-radius: 8px;
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  color: var(--pochi-text);
+  font-weight: 500;
+}
+
+#side-nav-close:focus {
+  outline: 2px solid var(--pochi-link);
+  outline-offset: 2px;
+}
+
+#side-nav-close::before,
+#side-nav-close::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 12px;
+  width: 18px;
+  height: 2px;
+  background: var(--pochi-text);
+  transform-origin: center;
+  transition: background-color 0.2s ease;
+}
+
+#side-nav-close::before {
+  transform: translate(0, -50%) rotate(45deg);
+}
+
+#side-nav-close::after {
+  transform: translate(0, -50%) rotate(-45deg);
+}
+
+#side-nav-close:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
 #side-nav-overlay {
   position: fixed;
   display: block;

--- a/layouts/partials/molecules/side_nav.html
+++ b/layouts/partials/molecules/side_nav.html
@@ -3,6 +3,16 @@
   class="menu-global-nav-for-phone-container"
   style="opacity: 0;"
 >
+  <div class="side-nav-header">
+    <button
+      id="side-nav-close"
+      class="side-nav-close"
+      type="button"
+      aria-label="Close menu"
+    >
+      Close
+    </button>
+  </div>
   <ul id="menu-global-nav-for-phone" class="menu">
     {{ range .Site.Menus.main }}
       {{ if .HasChildren }}


### PR DESCRIPTION
This PR:

- Adds a close button to the top of the side nav (left-aligned with an X icon and "Close" label).
- Closes the side nav when clicking links inside it, preserving navigation behavior (PJAX or full).
- Styles the header and button to match theme tokens; supports light/dark.

Manual verification:
- npm run serve
- Open the side nav via the menu icon.
- Click inside-nav links: nav closes and page navigates.
- Click the "Close" button: nav closes and overlay fades out.

Files touched:
- assets/js/main.js
- assets/scss/components/_nav.scss
- layouts/partials/molecules/side_nav.html

No breaking changes expected.
