### PR TITLE
feat(toc): render Hugo .TableOfContents and remove JS TOC

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -162,80 +162,6 @@ function handleThemeChange() {
   });
 }
 
-function buildTableOfContents() {
-  if (document.querySelector(".single-page") !== null) {
-    const firstH2 = document.querySelector("#contents h2");
-    if (firstH2 === null) {
-      return;
-    }
-
-    const headers = document.querySelectorAll(
-      "article h2, article h3, article h4, article h5, article h6",
-    );
-    let tableOfContents =
-      '<div class="table-of-contents"><p><span>Table of Contents</span></p><ol>';
-    let level = 0;
-    let currentLevel = 0;
-    let headerCounts = [
-      0, // h2
-      0, // h3
-      0, // h4
-      0, // h5
-      0, // h6
-    ];
-
-    for (let i = 0; i < headers.length; i++) {
-      level = parseInt(headers[i].tagName.charAt(1)) - 2;
-
-      while (currentLevel < level) {
-        tableOfContents += "<li><ol>";
-        currentLevel++;
-      }
-
-      while (currentLevel > level) {
-        tableOfContents += "</ol></li>";
-        currentLevel--;
-      }
-
-      let headerNumber = "";
-      for (let j = 0; j <= level; j++) {
-        if (j === level) {
-          headerCounts[j]++;
-          headerCounts[j + 1] = 0;
-        }
-        if (j === 0) {
-          headerNumber += headerCounts[j];
-        } else {
-          headerNumber += "-" + headerCounts[j];
-        }
-      }
-
-      headers[i].setAttribute("id", "index-toc-" + i);
-      tableOfContents +=
-        '<li><a href="#index-toc-' +
-        i +
-        '">' +
-        headerNumber +
-        ". " +
-        headers[i].textContent +
-        "</a></li>";
-    }
-
-    tableOfContents += "</ol></div>";
-
-    // Add the TOC to the page before the first h2 element
-    firstH2.insertAdjacentHTML("beforebegin", tableOfContents);
-
-    // Add the TOC to the sidebar
-    const sideBar = document.querySelector("#sidebar");
-    if (sideBar !== null) {
-      const asideEl = document.createElement("aside");
-      asideEl.innerHTML = tableOfContents;
-      sideBar.appendChild(asideEl);
-    }
-  }
-}
-
 // =============================
 // Search
 // =============================
@@ -438,6 +364,5 @@ onReady(() => {
   toggleSideNav();
   toggleTheme();
   handleThemeChange();
-  buildTableOfContents();
   initSearch();
 });

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -546,30 +546,35 @@ article,
   z-index: 5;
 }
 
-.table-of-contents ol {
+.table-of-contents ol,
+.table-of-contents ul {
   list-style-type: none;
   padding: 0 1rem;
   margin: 0;
   font-size: 0.9rem;
 }
 
-.table-of-contents ol li {
+.table-of-contents ol li,
+.table-of-contents ul li {
   text-align: left;
   letter-spacing: 1px;
   line-height: 2rem;
 }
 
-.table-of-contents ol li a {
+.table-of-contents ol li a,
+.table-of-contents ul li a {
   position: relative;
   display: inline-block;
   color: var(--pochi-text-muted);
 }
 
-.table-of-contents ol li a:hover {
+.table-of-contents ol li a:hover,
+.table-of-contents ul li a:hover {
   color: var(--pochi-accent);
 }
 
-.table-of-contents ol li a:after {
+.table-of-contents ol li a:after,
+.table-of-contents ul li a:after {
   display: block;
   content: "";
   position: absolute;
@@ -580,8 +585,59 @@ article,
   background-color: var(--pochi-accent);
 }
 
-.table-of-contents ol li a:hover:after {
+.table-of-contents ol li a:hover:after,
+.table-of-contents ul li a:hover:after {
   width: 100%;
+}
+
+/* Hugo .TableOfContents outputs a <nav><ul>… structure.
+   Add CSS counters to render hierarchical numbers similar to previous JS output. */
+.table-of-contents nav ul {
+  counter-reset: toc-item;
+}
+.table-of-contents nav li {
+  counter-increment: toc-item;
+}
+.table-of-contents nav li::before {
+  content: counters(toc-item, "-") ". ";
+  color: var(--pochi-text-muted);
+  margin-right: 0.25rem;
+}
+
+/* Reset global nav styles inside Hugo's TOC nav */
+.table-of-contents nav#TableOfContents {
+  background: transparent;
+  box-shadow: none;
+  position: static;
+  height: auto;
+  line-height: normal;
+  width: auto;
+  float: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  margin: 0;
+}
+.table-of-contents nav#TableOfContents ul {
+  margin: 0;
+  padding: 0 1rem;
+  line-height: normal;
+}
+.table-of-contents nav#TableOfContents li {
+  float: none; /* override global nav li float */
+}
+.table-of-contents nav#TableOfContents a {
+  display: inline-block; /* override global block links */
+  padding: 0; /* remove nav padding */
+  line-height: inherit;
+  background: transparent;
+}
+.table-of-contents nav#TableOfContents li:hover > a {
+  background: transparent; /* prevent global hover background */
+  color: var(--pochi-accent); /* keep visible in Light mode */
+}
+nav#TableOfContents li:before {
+  vertical-align: top;
 }
 
 /* -----page-nation----- */

--- a/layouts/partials/molecules/toc.html
+++ b/layouts/partials/molecules/toc.html
@@ -1,0 +1,9 @@
+{{/* Hugo-powered Table of Contents */}}
+{{ if .IsPage }}
+  {{ with .TableOfContents }}
+    <div class="table-of-contents">
+      <p><span>Table of Contents</span></p>
+      {{ . | safeHTML }}
+    </div>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/organisms/content.html
+++ b/layouts/partials/organisms/content.html
@@ -6,6 +6,7 @@
         <h1>{{ .Title }}</h1>
         {{ partial "molecules/post_meta_date.html" . }}
         {{ partial "molecules/post_meta_featured_image.html" . }}
+        {{ partial "molecules/toc.html" . }}
         <div>
           {{ .Content }}
         </div>

--- a/layouts/partials/organisms/sidebar.html
+++ b/layouts/partials/organisms/sidebar.html
@@ -8,5 +8,10 @@
         {{ partial "molecules/profile.html" . }}
       </aside>
     {{ end }}
+    {{ if .IsPage }}
+      <aside>
+        {{ partial "molecules/toc.html" $ }}
+      </aside>
+    {{ end }}
   </div>
 {{ end }}

--- a/layouts/partials/organisms/single_page_content.html
+++ b/layouts/partials/organisms/single_page_content.html
@@ -8,6 +8,7 @@
             <h1>{{ .Title }}</h1>
           {{ end }}
           {{ partial "molecules/post_meta_date.html" . }}
+          {{ partial "molecules/toc.html" . }}
           <div>
             {{ .Content }}
           </div>


### PR DESCRIPTION
## Summary
Replace the custom JS-generated table of contents with Hugo's built-in `.TableOfContents`, reducing JS and moving structure to templates.

## Why
- Simpler and more robust TOC generation (nesting and numbering handled by Hugo)
- Removes brittle DOM parsing logic
- Keeps styling consistent and accessible

## Changes
- Add `layouts/partials/molecules/toc.html` to render `.TableOfContents`
- Insert TOC in single content and sidebar
- Remove `buildTableOfContents()` and its call from `assets/js/main.js`
- Update styles to support `<nav id="TableOfContents">` output and reset global `nav` rules
  - Preserve previous look and feel, including hover and numbering via CSS counters

## Files
- `layouts/partials/molecules/toc.html`
- `layouts/partials/organisms/content.html`
- `layouts/partials/organisms/single_page_content.html`
- `layouts/partials/organisms/sidebar.html`
- `assets/js/main.js`
- `assets/scss/main.scss`

## Verification
- `npm run serve` and open a single post
- TOC appears before content and in sidebar
- Links navigate correctly; hover states remain visible in Light/Dark
- No JS errors; reduced bundle size (minor)

## Notes
No breaking changes expected; schema and other unrelated files are untouched in this PR.
