### PR TITLE
chore(js): data hooks + remove sync XHR in main.js

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,7 @@
 function smoothScroll() {
-  const scrollToTopBtn = document.getElementById("scroll-to-top");
+  const scrollToTopBtn =
+    document.querySelector('[data-pochi-scroll-top]') ||
+    document.getElementById("scroll-to-top");
 
   function scrollToTarget(targetEl) {
     window.scrollTo({
@@ -41,8 +43,12 @@ function smoothScroll() {
 }
 
 function toggleSideNav() {
-  const sideNav = document.querySelector("#side-nav");
-  const toggleBtn = document.getElementById("menu-bar-btn");
+  const sideNav =
+    document.querySelector('[data-pochi-side-nav]') ||
+    document.querySelector("#side-nav");
+  const toggleBtn =
+    document.querySelector('[data-pochi-menu-button]') ||
+    document.getElementById("menu-bar-btn");
   const isActiveClass = "is-active";
 
   let sideNavOverlay;
@@ -72,9 +78,11 @@ function toggleSideNav() {
     if (toggleBtn) toggleBtn.setAttribute("aria-expanded", "true");
     document.body.insertAdjacentHTML(
       "beforeend",
-      '<div id="side-nav-overlay"></div>',
+      '<div id="side-nav-overlay" data-pochi-side-nav-overlay></div>',
     );
-    sideNavOverlay = document.querySelector("#side-nav-overlay");
+    sideNavOverlay =
+      document.querySelector('[data-pochi-side-nav-overlay]') ||
+      document.querySelector("#side-nav-overlay");
   };
 
   const closeSideNav = (opts) => {
@@ -113,11 +121,11 @@ function toggleSideNav() {
 
     // Close the side nav when a link inside it is clicked
     const linkInsideSideNav = event.target.closest
-      ? event.target.closest("#side-nav a")
+      ? event.target.closest('[data-pochi-side-nav] a, #side-nav a')
       : null;
     // Close when the explicit close button is clicked
     const closeBtn = event.target.closest
-      ? event.target.closest("#side-nav-close")
+      ? event.target.closest('[data-pochi-side-nav-close], #side-nav-close')
       : null;
     if (isSideNavOpen && (linkInsideSideNav || closeBtn)) {
       closeSideNav({ returnFocus: true });
@@ -140,7 +148,9 @@ function toggleSideNav() {
 }
 
 function toggleTheme() {
-  const themeSwitch = document.getElementById("theme-toggle-switch");
+  const themeSwitch =
+    document.querySelector('[data-pochi-theme-toggle]') ||
+    document.getElementById("theme-toggle-switch");
   if (!themeSwitch) return;
   themeSwitch.addEventListener("click", () => {
     const root = document.documentElement; // keep in sync with head FOUC script
@@ -226,55 +236,6 @@ function executeSearch(searchQuery) {
   });
 }
 
-// urlExists() returns 'true' if the request was successful, 'false' if it was a 404.
-function urlExists(url) {
-  let http = new XMLHttpRequest();
-  http.open("HEAD", url, false);
-  http.send();
-  if (http.status != 404) return true;
-  else return false;
-}
-
-// TODO: Implement a makeFeaturedImageContainer.
-function makeFeaturedImageContainer(featuredImageURL) {
-  let container = "";
-  if (featuredImageURL !== "") {
-    const fileExtension = featuredImageURL.match(
-      /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/i,
-    )[0];
-    const isAVIF = fileExtension === ".avif";
-    const isWebP = fileExtension === ".webp";
-    let imgSrc = "";
-    let srcTag = "";
-
-    if (isAVIF || isWebP) {
-      const type = isAVIF ? "avif" : "webp";
-      srcTag = `<source srcset="${featuredImageURL}" type="image/${type}" />`;
-
-      const jpgPath = featuredImageURL.replace(
-        /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/i,
-        ".jpg",
-      );
-      const pngPath = featuredImageURL.replace(
-        /\.([0-9a-z]+)(?=[?#])|(\.)(?:[\w]+)$/i,
-        ".png",
-      );
-
-      if (urlExists(jpgPath)) {
-        imgSrc = jpgPath;
-      } else if (urlExists(pngPath)) {
-        imgSrc = pngPath;
-      }
-    } else {
-      imgSrc = featuredImageURL;
-    }
-
-    const imgTag = `<img src="${imgSrc}" alt="" loading="lazy" decoding="async" />`;
-    container = `<div class="post-image-col"><div class="featured-image-wrapper"><picture>${srcTag}${imgTag}</picture></div></div>`;
-  }
-
-  return container;
-}
 
 function populateResults(results) {
   var searchQuery = document.getElementById("search-query").value;
@@ -297,7 +258,6 @@ function populateResults(results) {
       publishDate: value.item.publishDate.split("T")[0],
       lastmod: value.item.lastmod.split("T")[0],
       featuredImage: "",
-      // featuredImage: makeFeaturedImageContainer("/" + value.item.featuredImage),
       snippet: snippet,
     });
     searchResults.innerHTML += output;

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -2,7 +2,7 @@
 // - Prefetch internal links on hover/touch
 // - Intercept clicks to replace only the main content area
 // - Update history and document title
-// - Re-run page-level initializers from main.js (buildTableOfContents, initSearch)
+// - Re-run page-level initializers from main.js (e.g., initSearch)
 
 (function () {
   const CACHE = new Map(); // url -> Promise<string> (HTML)
@@ -300,7 +300,6 @@
   function afterSwapInit() {
     try {
       // Functions declared in assets/js/main.js are global in classic scripts
-      if (typeof buildTableOfContents === "function") buildTableOfContents();
       if (typeof initSearch === "function") initSearch();
       // Other global listeners (smoothScroll, toggleSideNav, theme) use document-level
       // delegation and remain active across swaps.

--- a/layouts/partials/molecules/nav.html
+++ b/layouts/partials/molecules/nav.html
@@ -5,13 +5,14 @@
         >{{ .Site.Title }}</a
       >
       <div id="theme-toggle-switch-container">
-        <button id="theme-toggle-switch" aria-label="theme-toggle-switch">
+        <button id="theme-toggle-switch" data-pochi-theme-toggle aria-label="theme-toggle-switch">
           {{ partial "atoms/icon.html" (dict "id" "icon-light") }}
           {{ partial "atoms/icon.html" (dict "id" "icon-dark") }}
         </button>
       </div>
       <button
         id="menu-bar-btn"
+        data-pochi-menu-button
         type="button"
         class="menu-bar-btn"
         aria-label="メニュー"

--- a/layouts/partials/molecules/side_nav.html
+++ b/layouts/partials/molecules/side_nav.html
@@ -1,5 +1,6 @@
 <div
   id="side-nav"
+  data-pochi-side-nav
   class="menu-global-nav-for-phone-container"
   style="opacity: 0;"
   aria-hidden="true"
@@ -7,6 +8,7 @@
   <div class="side-nav-header">
     <button
       id="side-nav-close"
+      data-pochi-side-nav-close
       class="side-nav-close"
       type="button"
       aria-label="Close menu"

--- a/layouts/partials/organisms/footer.html
+++ b/layouts/partials/organisms/footer.html
@@ -27,7 +27,7 @@
       </p>
     </div>
   </footer>
-  <div id="scroll-to-top">
+  <div id="scroll-to-top" data-pochi-scroll-top>
     <a href="#top"> ▲<br />Top </a>
   </div>
 {{ end }}


### PR DESCRIPTION
Problem\n- Synchronous XHR and unused featured image builder in assets/js/main.js.\n- JS relied on ids/classes that are likely to change, risking regressions.\n- navigation.js referenced a nonexistent buildTableOfContents() reinit.\n\nApproach\n- Remove deprecated sync XHR helpers and the unused image builder.\n- Prefer data-pochi-* hooks in JS with id fallbacks; add data attributes in templates.\n- Drop TOC reinit hook; keep initSearch() call only.\n\nTrade-offs\n- Kept existing ids/classes and CSS selectors intact to avoid visual/regression risk.\n- Did not switch CSS to data hooks yet (can be a later PR).\n\nTesting\n- npm run serve; verify: theme toggle, side nav open/close/overlay/Escape, scroll-to-top, search init after client-side navigation.\n\nAssumptions\n- Teams agree on using data-pochi-* as stable JS hooks; ids remain for a11y (aria-controls, label-for).