### PR TITLE
feat(list): use mainSections for home pagination; align AdSense

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,9 @@
           <div class="article-list">
             {{ $paginator := slice }}
             {{ if .IsHome }}
-              {{ $paginator = .Paginate (where .Site.RegularPages "Section" "posts") }}
+              {{/* Use site.Params.mainSections to pick sections for the homepage list. Default covers common names. */}}
+              {{ $mainSections := or .Site.Params.mainSections (slice "post" "posts") }}
+              {{ $paginator = .Paginate (where .Site.RegularPages "Section" "in" $mainSections) }}
             {{ else }}
               {{ $paginator = .Paginate .Pages }}
             {{ end }}

--- a/layouts/partials/head/google_adsense.html
+++ b/layouts/partials/head/google_adsense.html
@@ -1,7 +1,9 @@
-{{ if eq .Section "posts" }}
+{{/* Include AdSense on single content pages in configured main sections */}}
+{{ $mainSections := or .Site.Params.mainSections (slice "post" "posts") }}
+{{ if and .IsPage (in $mainSections .Section) }}
   {{ with .Site.Params.GoogleAdsenseID }}
     <script
-      async=""
+      async
       src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-{{ . }}"
       crossorigin="anonymous"
     ></script>


### PR DESCRIPTION
Problem
- Home list used a hard-coded section name (`"posts"`), which breaks sites that use `content/post/` or other section names.
- AdSense inclusion relied on the same brittle check, leading to inconsistent behavior across sites.

Approach
- Paginate homepage content using `site.Params.mainSections` with a safe default of `["post", "posts"]`.
- Include AdSense only on single pages whose `.Section` is in `mainSections`.
- Keep all other behavior unchanged.

Trade-offs
- Sites wanting a mixed/aggregated homepage must customize separately; `mainSections` centralizes the definition of "main content" for consistency.

Testing
- `npm run serve`
  - Home shows posts for both `content/post/` and `content/posts/` setups.
  - AdSense script loads only on single pages within main sections.
  - No console errors on home, list, single, search, 404.

Assumptions
- `params.mainSections` is either unset (defaults applied) or a list of section names representing primary content.
