### PR TITLE
chore(head,js): sanitize meta description and minor JS polish

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -17,7 +17,7 @@ function smoothScroll() {
     if (!href || href.charAt(0) !== "#") return;
     event.preventDefault();
     if (href === "#top") {
-      window.scrollTo({ top: 0, behavior: "instant" });
+      window.scrollTo({ top: 0, behavior: "auto" });
     } else {
       const targetEl = document.querySelector(href);
       scrollToTarget(targetEl);
@@ -114,7 +114,8 @@ function toggleSideNav() {
     if (
       !isSideNavOpen &&
       event.target.closest &&
-      event.target.closest("#menu-bar-btn")
+      (event.target.closest('[data-pochi-menu-button]') ||
+        event.target.closest('#menu-bar-btn'))
     ) {
       // Handled by the button's listener; no-op here
     }

--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -11,17 +11,21 @@
     {{ .Site.Title }}
   {{ end }}
 </title>
+{{/* Build a sanitized meta description: prefer .Description, else page .Summary, else site param. */}}
+{{- $desc := "" -}}
+{{- with .Description -}}
+  {{- $desc = . -}}
+{{- else -}}
+  {{- if .IsPage -}}
+    {{- $desc = .Summary -}}
+  {{- else -}}
+    {{- with .Site.Params.description -}}{{ $desc = . }}{{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $descSan := $desc | plainify | htmlUnescape | replaceRE "\\s+" " " | truncate 160 -}}
 <meta
   name="description"
-  content="{{- with .Description -}}
-    {{ . }}
-  {{- else -}}
-    {{- if .IsPage -}}
-      {{- .Summary -}}
-    {{- else -}}
-      {{- with .Site.Params.description -}}{{ . }}{{- end -}}
-    {{- end -}}
-  {{- end -}}"
+  content="{{- $descSan -}}"
 />
 <meta
   name="keywords"


### PR DESCRIPTION
Problem
- Meta description could output raw HTML and excessive whitespace; this risks poor previews and validator noise.
- JS used a nonstandard `behavior: "instant"` for scroll-to-top and missed `data-pochi-menu-button` in a click guard.

Approach
- Build a sanitized description string in the template: `plainify` → `htmlUnescape` → collapse whitespace via `replaceRE` → `truncate 160`; then inject the prebuilt var into the meta tag.
- Replace scroll-to-top behavior with standards-compliant `behavior: "auto"`.
- Include `[data-pochi-menu-button]` in the side-nav click guard for consistency with our new data hooks.

Trade-offs
- None functionally; output is cleaner and more robust without changing visible UI.

Testing
- `npm run serve` builds without template errors.
- `<meta name="description">` renders as a single, clean line across pages.
- Top link (`#top`) still jumps instantly; side nav behavior unchanged.

Assumptions
- Keeping description length around ~160 chars meets SEO snippet norms.
