### PR TITLE
chore(vendor,ci): weekly auto-update for Fuse/Mark; ignore in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "fuse.js"
+      - dependency-name: "mark.js"
     groups:
       node-module-dependencies:
         patterns:

--- a/.github/workflows/vendor_auto_update.yml
+++ b/.github/workflows/vendor_auto_update.yml
@@ -1,0 +1,51 @@
+name: Vendor Libraries Auto Update
+
+on:
+  schedule:
+    - cron: "0 3 * * 1" # Every Monday at 03:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-vendors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Upgrade vendors to latest (may include majors)
+        run: npm run vendor:upgrade:major
+
+      - name: Verify vendor lock/hashes
+        run: npm run vendor:verify
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(vendor): upgrade Fuse/Mark to latest and sync vendor"
+          title: "chore(vendor): upgrade Fuse/Mark to latest"
+          body: |
+            This PR was created automatically to upgrade vendored search libraries to their latest versions and sync them into `assets/js/vendor/` via Hugo Pipes.
+
+            - Updated devDependencies (fuse.js, mark.js) using npm-check-updates
+            - Synced vendored files and updated VENDOR.lock.json
+            - Verified hashes with `npm run vendor:verify`
+
+            Review notes:
+            - Fuse.js may introduce behavior changes across major versions. Please verify search quality and performance.
+          branch: chore/vendor-auto-update
+          delete-branch: true
+          labels: dependencies,vendor,automation
+


### PR DESCRIPTION
Adds a scheduled workflow to auto‑upgrade vendored search libraries (Fuse.js/Mark.js) weekly and open a PR, and updates Dependabot to ignore these two packages to avoid duplicate PRs.

Details
- Workflow: `.github/workflows/vendor_auto_update.yml`
  - Triggers weekly and manually
  - Runs `npm run vendor:upgrade:major` to bump to latest (including majors)
  - Verifies `VENDOR.lock.json` and vendored files with `npm run vendor:verify`
  - Uses `peter-evans/create-pull-request` to open a PR
- Dependabot: ignore `fuse.js` and `mark.js` for npm ecosystem

Verification
- You can run the workflow with `workflow_dispatch` to confirm it opens a PR.

Notes
- This complements Dependabot. Other deps continue to be handled by Dependabot; search vendors are handled by this workflow + lock verification.