### PR TITLE
feat(comments): Giscus + PJAX re-init + theme sync, and i18n headings

### DIFF
--- a/layouts/partials/molecules/comment.html
+++ b/layouts/partials/molecules/comment.html
@@ -1,9 +1,39 @@
-{{ if .Site.Params.comment.enable }}
+{{/* Comments partial
+  - Controlled by .Site.Params.comment.enable (global) and .Params.comments (per page; false to disable)
+  - Providers: giscus | disqus (default legacy)
+*/}}
+{{ $enabled := and (.Site.Params.comment.enable) (ne .Params.comments false) .IsPage }}
+{{ if $enabled }}
   <div class="row">
     <div class="col-md-12 comment-wrapper">
-      <div class="mymenu-thumb mymenu-related-list">
-        <h3>コメントを残す</h3>
-        {{ template "_internal/disqus.html" . }}
+      <div class="mymenu-thumb mymenu-related-list comments">
+        <h3>{{ T "leave_a_comment" }}</h3>
+        {{ $provider := .Site.Params.comment.provider | default "disqus" }}
+        {{ if eq (lower $provider) "giscus" }}
+          {{ $g := .Site.Params.comment.giscus }}
+          {{ $slug := .Params.slug | default .File.TranslationBaseName | default .Title }}
+          <script
+            src="https://giscus.app/client.js"
+            data-repo="{{ $g.repo }}"
+            data-repo-id="{{ $g.repoId }}"
+            data-category="{{ $g.category }}"
+            data-category-id="{{ $g.categoryId }}"
+            data-mapping="{{ $g.mapping | default "specific" }}"
+            data-term="{{ $slug }}"
+            data-strict="{{ $g.strict | default "1" }}"
+            data-reactions-enabled="{{ $g.reactionsEnabled | default "1" }}"
+            data-emit-metadata="{{ $g.emitMetadata | default "0" }}"
+            data-input-position="{{ $g.inputPosition | default "bottom" }}"
+            data-theme="{{ $g.theme | default "preferred_color_scheme" }}"
+            data-lang="{{ .Site.Language.Lang }}"
+            crossorigin="anonymous"
+            async
+          ></script>
+          <noscript>Enable JavaScript to view comments.</noscript>
+        {{ else }}
+          {{/* Legacy fallback: Disqus via Hugo internal template */}}
+          {{ template "_internal/disqus.html" . }}
+        {{ end }}
       </div>
     </div>
   </div>

--- a/layouts/partials/molecules/related_posts.html
+++ b/layouts/partials/molecules/related_posts.html
@@ -6,7 +6,7 @@
   <div class="row">
     <div class="col-md-12 recent-posts-wrapper">
       <div class="mymenu-thumb mymenu-related-list">
-        <h3>関連記事</h3>
+        <h3>{{ T "related_posts" }}</h3>
         <div class="row">
           {{ range . }}
             <div class="col-sm-4 mymenu-related">


### PR DESCRIPTION
Problem
- Comments (Giscus) did not render after PJAX navigation; they only appeared after a full reload.
- Giscus theme did not follow the site dark/light toggle or OS preference changes.
- Comment/related section headings were not localized.

Approach
- Re-initialize Giscus after PJAX swaps by re-injecting the client script if no iframe is present.
- Sync theme to Giscus via postMessage setConfig({ theme: 'dark'|'light' }).
  - Update on site toggle, OS preference change, initial load, and right after PJAX re-init (with small retry until iframe is ready).
  - Guard cross-origin postMessage by extracting the iframe src origin before sending.
- Localize headings with Hugo i18n (`T`): `leave_a_comment`, `related_posts`.

Files
- assets/js/navigation.js: add Giscus re-init & theme sync call after PJAX.
- assets/js/main.js: add `updateGiscusTheme(WithRetry)` and hook into theme/OS changes.
- layouts/partials/molecules/comment.html: Giscus provider markup; i18n heading.
- layouts/partials/molecules/related_posts.html: i18n heading.

Notes / Trade-offs
- This PR focuses on the theme. Site-level params (provider=giscus, repo ids, mapping=specific) are assumed to be configured in the site repository.
- On pages without existing discussions, Giscus will 404 the lookup until a first comment/reaction is posted (expected).

Testing
- `make server` → open an article.
  - Navigate to another article (no reload): Giscus renders.
  - Toggle dark/light and change OS preference: Giscus theme updates.
  - Switch JA/EN: headings switch accordingly.

Assumptions
- Slug-based mapping shared across languages; stable slugs.
