### PR TITLE
feat(seo): add canonical/hreflang, PJAX hreflang swap, and WebSite JSON-LD

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -90,6 +90,10 @@
     removeAll('link[rel="canonical"], link[rel="prev"], link[rel="next"]');
     adoptAll('link[rel="canonical"], link[rel="prev"], link[rel="next"]');
 
+    // Replace language alternates (hreflang). Avoid RSS alternates by requiring [hreflang]
+    removeAll('link[rel="alternate"][hreflang]');
+    adoptAll('link[rel="alternate"][hreflang]');
+
     // Replace standard meta description/keywords/robots/theme-color/author
     removeAll(
       [

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -1,4 +1,47 @@
 {{ partial "head/meta.html" . }}
+{{/* Canonical URL */}}
+<link rel="canonical" href="{{ .Permalink }}" />
+
+{{/* Language alternates (hreflang) */}}
+{{- $ctx := . -}}
+{{- range .Site.Languages -}}
+  {{- $lang := . -}}
+  {{- $href := "" -}}
+  {{- $targets := where $ctx.AllTranslations "Lang" $lang.Lang -}}
+  {{- if gt (len $targets) 0 -}}
+    {{- $href = (index $targets 0).Permalink -}}
+  {{- else -}}
+    {{- $homeAlts := where $ctx.Site.Home.AllTranslations "Lang" $lang.Lang -}}
+    {{- if gt (len $homeAlts) 0 -}}
+      {{- $href = (index $homeAlts 0).Permalink -}}
+    {{- else -}}
+      {{- if eq $lang.Lang $ctx.Site.Language.Lang -}}
+        {{- $href = $ctx.Permalink -}}
+      {{- else -}}
+        {{- $href = (printf "%s%s/" $ctx.Site.BaseURL $lang.Lang) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  <link rel="alternate" hreflang="{{ $lang.Lang }}" href="{{ $href }}" />
+{{- end -}}
+
+{{/* x-default: default language or site root */}}
+{{- $defaultLang := (index (sort .Site.Languages "Weight" "asc") 0) -}}
+{{- if $defaultLang -}}
+  {{- $xHref := "" -}}
+  {{- $d := where .AllTranslations "Lang" $defaultLang.Lang -}}
+  {{- if gt (len $d) 0 -}}
+    {{- $xHref = (index $d 0).Permalink -}}
+  {{- else -}}
+    {{- $homeDefault := where .Site.Home.AllTranslations "Lang" $defaultLang.Lang -}}
+    {{- if gt (len $homeDefault) 0 -}}
+      {{- $xHref = (index $homeDefault 0).Permalink -}}
+    {{- else -}}
+      {{- $xHref = .Site.BaseURL -}}
+    {{- end -}}
+  {{- end -}}
+  <link rel="alternate" hreflang="x-default" href="{{ $xHref }}" />
+{{- end -}}
 {{ template "_internal/opengraph.html" . }}
 {{ template "_internal/twitter_cards.html" . }}
 {{ partial "head/schema.html" . }}

--- a/layouts/partials/head/schema.html
+++ b/layouts/partials/head/schema.html
@@ -23,18 +23,47 @@
   {{ end }}
 {{ end }}
 
-{{ $logo := dict "@type" "ImageObject" "url" $logoURL }}
+{{/* Build Logo ImageObject, enrich with width/height when available */}}
+{{ $logoW := 0 }}
+{{ $logoH := 0 }}
+{{ if .Site.Params.logo }}
+  {{ $webPath := .Site.Params.logo }}
+  {{ if and $webPath (ne (substr $webPath 0 1) "/") }}
+    {{ $webPath = printf "/%s" $webPath }}
+  {{ end }}
+  {{ $fsPath := printf "static%s" $webPath }}
+  {{ if (fileExists $fsPath) }}
+    {{ with imageConfig $fsPath }}
+      {{ $logoW = .Width }}
+      {{ $logoH = .Height }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $logo := cond (and (gt $logoW 0) (gt $logoH 0)) (dict "@type" "ImageObject" "url" $logoURL "width" $logoW "height" $logoH) (dict "@type" "ImageObject" "url" $logoURL) }}
+
+{{/* Resolve language code for JSON-LD (BCP47). Prefer .Site.LanguageCode; fallback to .Site.Language.Lang */}}
+{{ $langCode := or .Site.LanguageCode .Site.Language.Lang }}
 {{ if .IsPage }}
   {{ $datePublished := .PublishDate.Format "2006-01-02T15:04:05Z07:00" }}
   {{ $dateModified := .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}
   {{ $mainEntity := dict "@type" "WebPage" "@id" .Permalink }}
-  {{ $author := dict "@type" "Person" "name" .Site.Params.Author }}
+  {{/* Resolve author name and URL from site params */}}
+  {{ $authorName := "" }}
+  {{ with .Site.Params.profile.name }}
+    {{ $authorName = . }}
+  {{ else }}
+    {{ with .Site.Params.author }}{{ $authorName = . }}{{ end }}
+  {{ end }}
+  {{ $authorURL := "" }}
+  {{ with .Site.Params.authorURL }}{{ $authorURL = . }}{{ end }}
+  {{ $author := cond (ne $authorURL "") (dict "@type" "Person" "name" $authorName "url" $authorURL) (dict "@type" "Person" "name" $authorName) }}
   {{ $publisher := dict "@type" "Organization" "name" .Site.Params.Author "logo" $logo }}
   {{ $obj := dict
-    "@context" "https://schema.org/"
+    "@context" "https://schema.org"
     "@type" "BlogPosting"
     "headline" .Title
     "image" $imageURL
+    "inLanguage" $langCode
     "datePublished" $datePublished
     "dateModified" $dateModified
     "description" $desc
@@ -47,12 +76,34 @@
 {{ else }}
   {{ $siteURL := .Site.BaseURL }}
   {{ $siteName := .Site.Title }}
+
+  {{/* Organization (Logo) markup for home and other non-article pages */}}
   {{ $org := dict
     "@context" "https://schema.org"
     "@type" "Organization"
+    "@id" (printf "%s#organization" $siteURL)
     "name" $siteName
     "url" $siteURL
     "logo" $logo
   }}
   <script type="application/ld+json">{{ $org | jsonify | safeJS }}</script>
+  {{ if .IsHome }}
+    {{/* WebSite + Sitelinks Search Box (Rich Results対象) */}}
+    {{ $searchBase := ("search/" | absLangURL) }}
+    {{ $searchTarget := printf "%s?q={search_term_string}" $searchBase }}
+    {{ $website := dict
+      "@context" "https://schema.org"
+      "@type" "WebSite"
+      "@id" (printf "%s#website" $siteURL)
+      "url" $siteURL
+      "name" $siteName
+      "inLanguage" $langCode
+      "potentialAction" (dict
+      "@type" "SearchAction"
+      "target" $searchTarget
+      "query-input" "required name=search_term_string"
+      )
+    }}
+    <script type="application/ld+json">{{ $website | jsonify | safeJS }}</script>
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
This PR strengthens SEO and i18n signals and fixes stale head tags during PJAX navigation.\n\nChanges:\n- head: emit <link rel=canonical> and <link rel=alternate hreflang> (+ x-default)\n- pjax: swap 'link[rel=alternate][hreflang]' on client navigation\n- schema: add WebSite + SearchAction on home; enrich Logo with width/height; add inLanguage; support .Site.Params.authorURL for BlogPosting author.url\n\nNotes:\n- Respects defaultContentLanguageInSubdir=false.\n- RSS alternates unaffected.\n\nTesting:\n- Build site and inspect head on home/list/single; verify hreflang and canonical.\n- Navigate via PJAX and confirm alternates update.\n- Run Rich Results test on home for WebSite/Sitelinks Search Box.