### PR TITLE
fix(theme): avoid double page_view on PJAX (GA4)

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -438,21 +438,6 @@
         history.pushState({}, "", href);
       }
       afterSwapInit();
-      // Fire virtual pageview for common analytics if available
-      try {
-        if (window.gtag) {
-          // gtag.js: send page_view event with updated URL
-          window.gtag("event", "page_view", {
-            page_location: location.href,
-            page_path: location.pathname,
-            page_title: document.title,
-          });
-        } else if (window.ga) {
-          // analytics.js
-          window.ga("set", "page", location.pathname);
-          window.ga("send", "pageview");
-        }
-      } catch (_) {}
     } catch (e) {
       // Fallback to full navigation on error
       const href = typeof url === "string" ? url : url.href;


### PR DESCRIPTION
## Summary

Stop manual `page_view` dispatch on PJAX navigations and remove the legacy UA (`analytics.js`) branch to prevent double counting. Rely on GA4 Enhanced Measurement (history change tracking) for SPA page views.

## Background

Page views were being counted twice after PJAX transitions. Hugo injects GA4 via the internal template, which already auto-tracks SPA navigations on `pushState/replaceState/popstate`. Our theme’s `navigation.js` also sent a manual `gtag('event','page_view')` (and previously a UA fallback), resulting in duplicate page_view events.

## Notes

- Affected file: `assets/js/navigation.js`
- Behavior: Initial load still tracked by GA4 config; each PJAX navigation now emits exactly one `page_view`.
- GA4 setting: Ensure Enhanced Measurement “Page views (history change)” is ON; if it’s OFF, PJAX views won’t be tracked.
- Validation: In DevTools → Network, confirm a single GA4 `collect?v=2&en=page_view` per navigation.
- No UI/content changes; analytics-only adjustment. Comments related to GA4 manual tracking were removed for clarity.
