### PR TITLE
feat(theme): 3-column layout, archives improvements, a11y

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -5,3 +5,26 @@ html {
 body {
   font-family: var(--pochi-font-base);
 }
+
+/* Skip to content link: visible on keyboard focus */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 0.75rem;
+  background: var(--pochi-accent);
+  color: var(--pochi-on-accent);
+  border-radius: 6px;
+  outline: 2px solid var(--pochi-on-accent);
+  outline-offset: 2px;
+  z-index: 1001;
+}

--- a/assets/css/components/footer.css
+++ b/assets/css/components/footer.css
@@ -34,6 +34,7 @@ footer .copyright a:hover {
 }
 
 #sidebar h2,
+#sidebar-left h2,
 footer h2 {
   position: relative;
   text-align: center;
@@ -43,6 +44,7 @@ footer h2 {
 }
 
 #sidebar h2:before,
+#sidebar-left h2:before,
 footer h2:before {
   content: "";
   display: block;
@@ -64,6 +66,7 @@ footer h2:before {
 }
 
 #sidebar h2 span,
+#sidebar-left h2 span,
 footer h2 span {
   background: var(--pochi-bg);
   padding: 0 10px;
@@ -76,12 +79,14 @@ footer h2 span {
 }
 
 #sidebar p,
+#sidebar-left p,
 footer p {
   font-size: 0.9rem;
   line-height: 1.5rem;
 }
 
 #sidebar ul,
+#sidebar-left ul,
 footer ul {
   font-size: 0.9rem;
 }

--- a/assets/css/components/lists.css
+++ b/assets/css/components/lists.css
@@ -22,3 +22,59 @@ article blockquote ol,
 article blockquote ul {
   margin-bottom: 0;
 }
+
+/* Archives page toggles */
+.archive-year > summary {
+  list-style: none;
+  cursor: pointer;
+  position: relative;
+  padding-left: 1.1rem;
+}
+.archive-year > summary::-webkit-details-marker {
+  display: none;
+}
+.archive-year > summary::before {
+  content: '▸';
+  position: absolute;
+  left: 0;
+  top: 0.2rem;
+}
+.archive-year[open] > summary::before {
+  content: '▾';
+}
+
+/* Month-level toggles on /archives */
+.archive-month h3 {
+  margin: 0.5rem 0;
+}
+.archive-month-toggle {
+  background: transparent;
+  border: 0;
+  padding: 0 0 0 1.1rem;
+  color: var(--pochi-text);
+  cursor: pointer;
+  font: inherit;
+  position: relative;
+}
+.archive-month-toggle::before {
+  content: '▸';
+  position: absolute;
+  left: 0;
+  top: 0.1rem;
+}
+.archive-month-toggle[aria-expanded="true"]::before {
+  content: '▾';
+}
+.archive-month-cards.is-collapsed {
+  display: none;
+}
+
+/* Cards-only mode on archives page: show only post cards */
+#contents.cards-only-mode > h1,
+#contents.cards-only-mode details.archive-year > summary,
+#contents.cards-only-mode .archive-month > h3 {
+  display: none !important;
+}
+#contents.cards-only-mode details.archive-year:not(.is-selected-year) {
+  display: none !important;
+}

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -1,35 +1,49 @@
 /* Sidebar-specific styles (extracted from main.scss) */
 
-#sidebar aside:last-child {
+#sidebar aside:last-child,
+#sidebar-left aside:last-child,
+#sidebar-right aside:last-child {
   position: -webkit-sticky;
   position: sticky;
   top: 5.5rem;
   margin-bottom: 3rem;
 }
 
-#sidebar .table-of-contents {
+#sidebar .table-of-contents,
+#sidebar-left .table-of-contents,
+#sidebar-right .table-of-contents {
   background-color: var(--pochi-card);
   border: none;
   max-height: 86vh;
   overflow-y: auto;
 }
 
-#sidebar .table-of-contents p {
+#sidebar .table-of-contents p,
+#sidebar-left .table-of-contents p,
+#sidebar-right .table-of-contents p {
   margin-top: 1rem;
 }
 
-#sidebar aside {
+#sidebar aside,
+#sidebar-left aside,
+#sidebar-right aside {
   margin-bottom: 2rem;
 }
 
-#sidebar a {
+#sidebar a,
+#sidebar-left a,
+#sidebar-right a {
   color: var(--pochi-text-muted);
 }
-#sidebar a:hover {
+#sidebar a:hover,
+#sidebar-left a:hover,
+#sidebar-right a:hover {
   color: var(--pochi-accent);
 }
 
-#sidebar .profile-flex-box {
+#sidebar .profile-flex-box,
+#sidebar-left .profile-flex-box,
+#sidebar-right .profile-flex-box {
   display: -webkit-box;
   display: -moz-box;
   display: -ms-flexbox;
@@ -41,7 +55,9 @@
   justify-content: space-around;
 }
 
-#sidebar #profile-image {
+#sidebar #profile-image,
+#sidebar-left #profile-image,
+#sidebar-right #profile-image {
   float: left;
   height: 30%;
   width: 30%;
@@ -50,7 +66,9 @@
   overflow: hidden;
 }
 
-#sidebar .tagcloud a {
+#sidebar .tagcloud a,
+#sidebar-left .tagcloud a,
+#sidebar-right .tagcloud a {
   background-color: var(--pochi-card);
   color: var(--pochi-text-muted);
   font-size: 0.75rem !important;
@@ -62,13 +80,61 @@
   border-radius: 2px;
 }
 
-#sidebar .tagcloud a:hover {
+#sidebar .tagcloud a:hover,
+#sidebar-left .tagcloud a:hover,
+#sidebar-right .tagcloud a:hover {
   background-color: var(--pochi-accent);
   color: var(--pochi-on-accent);
 }
 
 @media (max-width: 767px) {
-  #sidebar {
+  #sidebar,
+  #sidebar-left,
+  #sidebar-right {
     margin-left: 0rem;
   }
+}
+
+/* Dark theme adjustments to match right sidebar heading */
+.dark #sidebar-left h2 span {
+  background-color: var(--pochi-surface-soft);
+}
+.dark #sidebar-left h2:before {
+  background-image: linear-gradient(
+    to right,
+    var(--pochi-separator-end-dark),
+    var(--pochi-separator-mid-dark),
+    var(--pochi-separator-end-dark)
+  );
+}
+
+/* Archives collapsible list */
+#sidebar-left .archives-year {}
+#sidebar-left .archives-year-toggle {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  padding: 0.25rem 0 0.25rem 1.1rem;
+  color: var(--pochi-text-muted);
+  cursor: pointer;
+  position: relative;
+}
+#sidebar-left .archives-year-toggle::before {
+  content: '▸';
+  position: absolute;
+  margin-left: -1.1rem;
+  margin-top: 0.1rem;
+}
+#sidebar-left .archives-year-toggle[aria-expanded="true"]::before {
+  content: '▾';
+}
+#sidebar-left .archives-year-toggle:hover {
+  color: var(--pochi-accent);
+}
+#sidebar-left .archives-months {
+  margin-left: 1.1rem;
+}
+#sidebar-left .archives-months.is-collapsed {
+  display: none;
 }

--- a/assets/css/layout/grid.css
+++ b/assets/css/layout/grid.css
@@ -42,9 +42,21 @@
     flex: 0 0 auto;
     width: 100%;
   }
+  /* Desktop visual order: left (1) -> contents (2) -> right (3) */
+  #sidebar-left { order: 1; }
+  #contents { order: 2; }
+  #sidebar { order: 3; }
+  .col-md-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
   .col-md-9 {
     flex: 0 0 auto;
     width: 75%;
+  }
+  .col-md-7 {
+    flex: 0 0 auto;
+    width: 58.33333333%;
   }
   .col-md-8 {
     flex: 0 0 auto;
@@ -57,4 +69,14 @@
   .col-md-3 {
     width: 25%;
   }
+}
+
+#sidebar-left,
+#sidebar-right,
+#contents,
+#sidebar,
+.col-md-12,
+.col-sm-4 {
+  padding-right: 1rem;
+  padding-left: 1rem;
 }

--- a/assets/js/archives-toggle.js
+++ b/assets/js/archives-toggle.js
@@ -1,0 +1,109 @@
+// Delegate clicks so it keeps working across PJAX swaps
+(function initArchivesToggleDelegation() {
+  function onClick(e) {
+    // Left sidebar year toggle
+    const yearBtn = e.target && e.target.closest
+      ? e.target.closest('#sidebar-left .archives-year-toggle')
+      : null;
+    if (yearBtn) {
+      const year = yearBtn.getAttribute('data-year');
+      if (!year) return;
+      const target = document.getElementById(`archives-months-${year}`);
+      if (!target) return;
+      const isCollapsed = target.classList.toggle('is-collapsed');
+      try {
+        yearBtn.setAttribute('aria-expanded', (!isCollapsed).toString());
+      } catch (_) {}
+      return;
+    }
+
+    // Archives page month toggle (card view)
+    const monthBtn = e.target && e.target.closest
+      ? e.target.closest('.archive-month-toggle')
+      : null;
+    if (monthBtn) {
+      const month = monthBtn.getAttribute('data-month');
+      if (!month) return;
+      showMonthCards(month, { scrollIntoView: false, updateHash: true });
+    }
+  }
+
+  if (!document.__pochiArchivesDelegated) {
+    document.addEventListener('click', onClick);
+    document.__pochiArchivesDelegated = true;
+  }
+
+  function isArchivesPage() {
+    return !!document.querySelector('.archive-year');
+  }
+
+  function openYearForMonth(monthKey) {
+    const year = (monthKey || '').slice(0, 4);
+    if (!year) return;
+    const yearHeading = document.getElementById(year);
+    if (!yearHeading) return;
+    const details = yearHeading.closest('details.archive-year');
+    if (details) details.open = true;
+  }
+
+  function showMonthCards(monthKey, opts) {
+    if (!isArchivesPage()) return;
+    openYearForMonth(monthKey);
+    const all = document.querySelectorAll('.archive-month-cards');
+    all.forEach((el) => el.classList.add('is-collapsed'));
+    const target = document.getElementById(`cards-${monthKey}`);
+    if (!target) return;
+    target.classList.remove('is-collapsed');
+    // Mark selected year to hide others in cards-only mode
+    try {
+      document.querySelectorAll('details.archive-year').forEach(d => d.classList.remove('is-selected-year'));
+      const selectedYear = target.closest('details.archive-year');
+      if (selectedYear) selectedYear.classList.add('is-selected-year');
+    } catch (_) {}
+    // Enter cards-only mode: hide headings and non-selected years
+    try {
+      const contents = document.getElementById('contents');
+      if (contents) contents.classList.add('cards-only-mode');
+    } catch (_) {}
+    // Update aria-expanded on toggles
+    document.querySelectorAll('.archive-month-toggle').forEach((b) => {
+      const k = b.getAttribute('data-month');
+      b.setAttribute('aria-expanded', k === monthKey ? 'true' : 'false');
+    });
+    if (opts && opts.updateHash) {
+      try { history.replaceState({}, '', `#${monthKey}`); } catch (_) {}
+    }
+    if (opts && opts.scrollIntoView) {
+      try {
+        const h = document.getElementById(monthKey);
+        if (h) h.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      } catch (_) {}
+    }
+  }
+
+  function showFromHash() {
+    if (!isArchivesPage()) return;
+    const hash = (location.hash || '').replace('#', '');
+    if (/^\d{4}-\d{2}$/.test(hash)) {
+      showMonthCards(hash, { scrollIntoView: true, updateHash: false });
+    } else {
+      // Collapse all by default on archives page
+      document.querySelectorAll('.archive-month-cards').forEach((el) => el.classList.add('is-collapsed'));
+      document.querySelectorAll('.archive-month-toggle').forEach((b) => b.setAttribute('aria-expanded', 'false'));
+      try {
+        document.querySelectorAll('details.archive-year').forEach(d => d.classList.remove('is-selected-year'));
+        const contents = document.getElementById('contents');
+        if (contents) contents.classList.remove('cards-only-mode');
+      } catch (_) {}
+    }
+  }
+
+  // Initial run and listeners for hash changes and PJAX swaps
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', showFromHash, { once: true });
+  } else {
+    showFromHash();
+  }
+  window.addEventListener('hashchange', showFromHash);
+  document.addEventListener('pochi:afterSwap', showFromHash);
+})();

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -438,6 +438,10 @@
         history.pushState({}, "", href);
       }
       afterSwapInit();
+      try {
+        const href = doc.location ? doc.location.href : (typeof url === 'string' ? url : url.href);
+        document.dispatchEvent(new CustomEvent('pochi:afterSwap', { detail: { href } }));
+      } catch (_) {}
     } catch (e) {
       // Fallback to full navigation on error
       const href = typeof url === "string" ? url : url.href;

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -49,9 +49,6 @@ other = "Categories"
 [archives]
 other = "Archives"
 
-[view_all_archives]
-other = "View all"
-
 [no_categories]
 other = "No categories yet"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -42,3 +42,21 @@ other = "Leave a comment"
 
 [related_posts]
 other = "Related posts"
+
+[categories]
+other = "Categories"
+
+[archives]
+other = "Archives"
+
+[view_all_archives]
+other = "View all"
+
+[no_categories]
+other = "No categories yet"
+
+[no_archives]
+other = "No posts yet"
+
+[skip_to_content]
+other = "Skip to content"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -49,9 +49,6 @@ other = "カテゴリー"
 [archives]
 other = "月別アーカイブ"
 
-[view_all_archives]
-other = "すべて見る"
-
 [no_categories]
 other = "カテゴリーはまだないよ"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -42,3 +42,21 @@ other = "コメントを残す"
 
 [related_posts]
 other = "関連記事"
+
+[categories]
+other = "カテゴリー"
+
+[archives]
+other = "月別アーカイブ"
+
+[view_all_archives]
+other = "すべて見る"
+
+[no_categories]
+other = "カテゴリーはまだないよ"
+
+[no_archives]
+other = "まだ投稿がないよ"
+
+[skip_to_content]
+other = "本文へスキップ"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,6 +12,7 @@
     {{ partial "head/head.html" . }}
   </head>
   <body>
+    <a class="skip-link" href="#main-content">{{ T "skip_to_content" }}</a>
     {{ block "header" . }}
     {{ end }}
     {{ block "main" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,7 +5,7 @@
     {{ end }}
     <div class="container-fluid">
       <div class="row">
-        <div class="col-md-9" id="contents">
+        <div class="col-md-7" id="contents">
           <div class="article-list">
             {{ $paginator := slice }}
             {{ if .IsHome }}
@@ -35,8 +35,12 @@
             </div>
           </div>
         </div>
-        {{ block "sidebar" . }}
-        {{ end }}
+        <div class="col-md-2" id="sidebar-left">
+          {{ partial "organisms/sidebar_left.html" . }}
+        </div>
+        <div class="col-md-3" id="sidebar">
+          {{ partial "organisms/sidebar_right.html" . }}
+        </div>
       </div>
     </div>
   </main>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,7 +3,7 @@
     {{ partial "molecules/breadcrumbs.html" . }}
     <div class="container-fluid">
       <div class="row">
-        <div class="col-md-9" id="contents">
+        <div class="col-md-7" id="contents">
           {{ range sort .Pages "Title" "asc" }}
             <ul>
               <li>
@@ -12,8 +12,12 @@
             </ul>
           {{ end }}
         </div>
-        {{ block "sidebar" . }}
-        {{ end }}
+        <div class="col-md-2" id="sidebar-left">
+          {{ partial "organisms/sidebar_left.html" . }}
+        </div>
+        <div class="col-md-3" id="sidebar">
+          {{ partial "organisms/sidebar_right.html" . }}
+        </div>
       </div>
     </div>
   </main>

--- a/layouts/archives/list.html
+++ b/layouts/archives/list.html
@@ -1,0 +1,51 @@
+{{ define "main" }}
+  <main id="main-content" class="main-content" role="main">
+    {{ partial "molecules/breadcrumbs.html" . }}
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-7" id="contents">
+          <h1>{{ i18n "archives" | default "Archives" }}</h1>
+          {{ $mainSections := or .Site.Params.mainSections (slice "post" "posts") }}
+          {{ $pages := where .Site.RegularPages "Section" "in" $mainSections }}
+          {{ $years := sort ($pages.GroupByDate "2006") "Key" "desc" }}
+          {{ range $i, $y := $years }}
+            <details class="archive-year" {{ if eq $i 0 }}open{{ end }}>
+              <summary><h2 id="{{ $y.Key }}">{{ $y.Key }}</h2></summary>
+              {{ $months := sort ($y.Pages.GroupByDate "2006-01") "Key" "desc" }}
+              {{ range $m := $months }}
+                <section class="archive-month" id="section-{{ $m.Key }}">
+                  <h3 id="{{ $m.Key }}">
+                    <button
+                      type="button"
+                      class="archive-month-toggle"
+                      data-month="{{ $m.Key }}"
+                      aria-controls="cards-{{ $m.Key }}"
+                      aria-expanded="false"
+                    >
+                      {{ $m.Key }}
+                    </button>
+                  </h3>
+                  <div
+                    id="cards-{{ $m.Key }}"
+                    class="archive-month-cards article-list is-collapsed"
+                    data-month="{{ $m.Key }}"
+                  >
+                    {{ range $p := $m.Pages }}
+                      {{ partial "organisms/list_of_posts.html" (dict "page" $p "priority" false) }}
+                    {{ end }}
+                  </div>
+                </section>
+              {{ end }}
+            </details>
+          {{ end }}
+        </div>
+        <div class="col-md-2" id="sidebar-left">
+          {{ partial "organisms/sidebar_left.html" . }}
+        </div>
+        <div class="col-md-3" id="sidebar">
+          {{ partial "organisms/sidebar_right.html" . }}
+        </div>
+      </div>
+    </div>
+  </main>
+{{ end }}

--- a/layouts/partials/core/resources_js.html
+++ b/layouts/partials/core/resources_js.html
@@ -1,4 +1,5 @@
 {{ $main := resources.Get "js/main.js" }}
 {{ $nav := resources.Get "js/navigation.js" }}
-{{ $bundle := slice $main $nav | resources.Concat "js/bundle.js" | resources.Minify | fingerprint }}
+{{ $archives := resources.Get "js/archives-toggle.js" }}
+{{ $bundle := slice $main $nav $archives | resources.Concat "js/bundle.js" | resources.Minify | fingerprint }}
 <script defer src="{{ $bundle.RelPermalink }}"></script>

--- a/layouts/partials/organisms/sidebar_left.html
+++ b/layouts/partials/organisms/sidebar_left.html
@@ -1,0 +1,49 @@
+<aside>
+  <h2 class="widgettitle"><span>{{ i18n "categories" | default "Categories" }}</span></h2>
+  {{ $cats := .Site.Taxonomies.categories }}
+  {{ if $cats }}
+    <ul class="list-unstyled">
+      {{ range $name, $pages := $cats }}
+        {{ $termPage := site.GetPage (printf "/categories/%s" ($name | urlize)) }}
+        <li>
+          {{ if $termPage }}
+            <a href="{{ $termPage.RelPermalink }}">{{ $name }} ({{ len $pages }})</a>
+          {{ else }}
+            {{ $name }} ({{ len $pages }})
+          {{ end }}
+        </li>
+      {{ end }}
+    </ul>
+  {{ else }}
+    <p>{{ i18n "no_categories" | default "No categories yet" }}</p>
+  {{ end }}
+</aside>
+
+<aside>
+  <h2 class="widgettitle"><span>{{ i18n "archives" | default "Archives" }}</span></h2>
+  {{ $mainSections := or .Site.Params.mainSections (slice "post" "posts") }}
+  {{ $pages := where .Site.RegularPages "Section" "in" $mainSections }}
+  {{ $years := sort ($pages.GroupByDate "2006") "Key" "desc" }}
+  {{ if gt (len $years) 0 }}
+    <ul class="list-unstyled archives-list">
+      {{ range $i, $y := $years }}
+        {{ $year := $y.Key }}
+        <li class="archives-year">
+          <button class="archives-year-toggle" type="button" data-year="{{ $year }}" aria-controls="archives-months-{{ $year }}" aria-expanded="{{ if eq $i 0 }}true{{ else }}false{{ end }}">
+            {{ $year }}
+          </button>
+          {{ $months := sort ($y.Pages.GroupByDate "2006-01") "Key" "desc" }}
+          <ul id="archives-months-{{ $year }}" class="archives-months{{ if ne $i 0 }} is-collapsed{{ end }}">
+            {{ range $m := $months }}
+              <li>
+                <a href="{{ "/archives/#" | relLangURL }}{{ $m.Key }}">{{ $m.Key }} ({{ len $m.Pages }})</a>
+              </li>
+            {{ end }}
+          </ul>
+        </li>
+      {{ end }}
+    </ul>
+  {{ else }}
+    <p>{{ i18n "no_archives" | default "No posts yet" }}</p>
+  {{ end }}
+</aside>

--- a/layouts/partials/organisms/sidebar_right.html
+++ b/layouts/partials/organisms/sidebar_right.html
@@ -1,0 +1,9 @@
+<aside>
+  {{ partial "molecules/search_form.html" }}
+  </aside>
+{{ with .Site.Params.Profile }}
+  <aside>
+    {{ partial "molecules/profile.html" . }}
+  </aside>
+{{ end }}
+


### PR DESCRIPTION
Problem
- Need dual sidebars with better discoverability (categories + monthly archives)
- Archives lacked collapsible years and consistent cards UI
- PJAX navigations broke month/year toggles after page swap
- A11y: missing skip-to-content link

Approach
- Switch home/terms/archives to 2-7-3 layout (desktop), keep mobile DOM as content->left->right
- Left sidebar: categories + year-grouped archives with arrow indicators
- Archives page: month click shows only that month as cards (post-row)
- JS: delegate events for year/month toggles; fire custom pochi:afterSwap; consume hash (#YYYY-MM)
- Add skip-to-content link and styles; add i18n strings

Trade-offs
- Archives page now uses details/summary for years; hash navigation reveals selected month and hides headings
- Subtle CSS additions to keep style consistent in dark/light modes

Tests
- Hugo build locally; desktop/mobile layouts verified
- PJAX nav between pages keeps archive toggles working

Assumptions
- Submodule consumers will bump pointer after merge
