### PR TITLE
fix(theme/a11y): sidebar ARIA, contrast, and touch targets

### DIFF
--- a/assets/css/components/code.css
+++ b/assets/css/components/code.css
@@ -51,6 +51,21 @@ ol li > code {
 .dark p > code,
 .dark ul li > code,
 .dark ol li > code {
-  color: var(--pochi-code-text);
+  /* Use defined token name; was --pochi-code-text (undefined) */
+  color: var(--pochi-code-fg);
+  background-color: var(--pochi-code-bg);
+}
+
+/* Ensure inline code in post list excerpts matches article styling */
+.article-list .post-excerpt code {
+  color: var(--pochi-text);
+  padding: 0.2rem 0.4rem;
+  background-color: var(--pochi-inline-code-bg);
+  border: 1px solid var(--pochi-inline-code-border);
+  border-radius: 0.25rem;
+}
+
+.dark .article-list .post-excerpt code {
+  color: var(--pochi-code-fg);
   background-color: var(--pochi-code-bg);
 }

--- a/assets/css/components/profile.css
+++ b/assets/css/components/profile.css
@@ -1,3 +1,16 @@
-.profile-link {
-  line-height: 2rem;
+/* Right/standard sidebar profile links: comfortable tap targets */
+#sidebar-right .profile-link,
+#sidebar .profile-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px; /* match visual line-height (2rem) */
+  padding: 0 0.5rem; /* horizontal breathing room */
+  margin: 0.25rem 0; /* 4px上下 → 隣接リンク間で8px */
+  border-radius: 0.25rem;
+  line-height: 2rem; /* 約32pxの視覚高さ */
+}
+
+#sidebar-right .profile-link:hover,
+#sidebar .profile-link:hover {
+  background: var(--pochi-hover);
 }

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -167,16 +167,22 @@
   text-align: left;
   background: transparent;
   border: 0;
-  padding: 0.25rem 0 0.25rem 1.1rem;
+  /* Increase tappable area while keeping visuals compact */
+  padding: 0.5rem 0 0.5rem 1.1rem; /* 8px top/bottom */
+  min-height: 32px; /* try 32px per request */
+  margin: 0.25rem 0; /* 4px gap above/below → 8px between neighbors */
   color: var(--pochi-text-muted);
   cursor: pointer;
   position: relative;
+  display: flex;
+  align-items: center;
 }
 #sidebar-left .archives-year-toggle::before {
   content: "▸";
   position: absolute;
   margin-left: -1.1rem;
-  margin-top: 0.1rem;
+  top: 50%;
+  transform: translateY(-50%);
 }
 #sidebar-left .archives-year-toggle[aria-expanded="true"]::before {
   content: "▾";
@@ -186,6 +192,25 @@
 }
 #sidebar-left .archives-months {
   margin-left: 1.1rem;
+  margin-top: 0.25rem; /* add separation from year toggle */
+}
+
+/* Make category links and archive month links comfortable tap targets */
+#sidebar-left ul.list-unstyled > li > a,
+#sidebar-left .archives-months a {
+  display: block;
+  padding: 0.5rem 0.5rem; /* 8px vertical + 8px horizontal padding */
+  margin: 0.25rem 0; /* 4px gap above/below → 8px between neighbors */
+  min-height: 32px; /* ensure >= 32px target size */
+  display: flex;
+  align-items: center;
+  border-radius: 0.25rem;
+}
+
+/* Hover/active feedback remains consistent */
+#sidebar-left ul.list-unstyled > li > a:hover,
+#sidebar-left .archives-months a:hover {
+  background: var(--pochi-hover);
 }
 #sidebar-left .archives-months.is-collapsed {
   display: none;

--- a/layouts/partials/organisms/sidebar_left.html
+++ b/layouts/partials/organisms/sidebar_left.html
@@ -34,23 +34,20 @@
     <ul class="list-unstyled archives-list">
       {{ range $i, $y := $years }}
         {{ $year := $y.Key }}
+        {{ $isOpen := eq $i 0 }}
         <li class="archives-year">
           <button
             class="archives-year-toggle"
             type="button"
             data-year="{{ $year }}"
             aria-controls="archives-months-{{ $year }}"
-            aria-expanded="{{ if eq $i 0 }}
-              true
-            {{ else }}
-              false
-            {{ end }}"
+            aria-expanded="{{ printf "%t" $isOpen }}"
           >
             {{ $year }}
           </button>
           {{ $months := sort ($y.Pages.GroupByDate "2006-01") "Key" "desc" }}
           {{ $monthsClasses := slice "archives-months" }}
-          {{ if ne $i 0 }}
+          {{ if not $isOpen }}
             {{ $monthsClasses = $monthsClasses | append "is-collapsed" }}
           {{ end }}
           <ul


### PR DESCRIPTION
Automated theme PR

Changes scoped to: hugo/themes/pochi

Files:
 - assets/css/components/code.css
 - assets/css/components/profile.css
 - assets/css/components/sidebar.css
 - layouts/partials/organisms/sidebar_left.html

**Notes:**
- Generated by scripts/theme_pr.sh
